### PR TITLE
Plugin crash when a method in controller doesn't have value parameter

### DIFF
--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/parser/SpringMvcResourceParser.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/parser/SpringMvcResourceParser.java
@@ -365,7 +365,7 @@ public class SpringMvcResourceParser extends ResourceParser {
 			name += NamingHelper.resolveProperties(classController.value());
 		}
 
-		if (methodMapping.value() != null) {
+		if (methodMapping.value() != null && methodMapping.value().length > 0) {
 			if (name.endsWith("/") && methodMapping.value()[0].startsWith("/")) {
 				name = name.substring(0, name.length() - 1);
 			} else if (name != "" && !name.endsWith("/") && !methodMapping.value()[0].startsWith("/")) {

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/SpringMvcResourceParserTest.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/SpringMvcResourceParserTest.java
@@ -389,7 +389,6 @@ public class SpringMvcResourceParserTest {
 	public void test_bug_noValueOnMethod() {
 		Resource resourceInfo = parser.extractResourceInfo(NoValueController.class);
 		assertEquals(0, resourceInfo.getResource("/base").getResources().size());
-		//assertEquals(ActionType.GET, resourceInfo.getResource("/base").)
 		assertNotNull(resourceInfo);
 	}
 }

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/SpringMvcResourceParserTest.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/SpringMvcResourceParserTest.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 
 import test.phoenixnap.oss.plugin.naming.testclasses.BugController;
+import test.phoenixnap.oss.plugin.naming.testclasses.NoValueController;
 import test.phoenixnap.oss.plugin.naming.testclasses.TestController;
 
 import com.phoenixnap.oss.ramlapisync.javadoc.JavaDocEntry;
@@ -384,4 +385,11 @@ public class SpringMvcResourceParserTest {
 		assertNotNull(testResource);
 	}
 
+	@Test
+	public void test_bug_noValueOnMethod() {
+		Resource resourceInfo = parser.extractResourceInfo(NoValueController.class);
+		assertEquals(0, resourceInfo.getResource("/base").getResources().size());
+		//assertEquals(ActionType.GET, resourceInfo.getResource("/base").)
+		assertNotNull(resourceInfo);
+	}
 }

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/testclasses/NoValueController.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/testclasses/NoValueController.java
@@ -1,0 +1,22 @@
+package test.phoenixnap.oss.plugin.naming.testclasses;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ *
+ * @author Emmanuel TOURDOT
+ * @since 0.2.1
+ *
+ */
+@RestController
+@RequestMapping("/base")
+public class NoValueController {
+
+  @RequestMapping(method = { RequestMethod.GET })
+  public String simpleMethodAllHttpMethods() {
+    return null;
+  }
+
+}


### PR DESCRIPTION
Sample with NoValueController into this PR:
```
@RestController
@RequestMapping("/base")
public class NoValueController {
  @RequestMapping(method = { RequestMethod.GET })
  public String simpleMethodAllHttpMethods() {
    return null;
  }
}
```
This controller cause a crash like this:
```
java.lang.ArrayIndexOutOfBoundsException: 0
at com.phoenixnap.oss.ramlapisync.parser.SpringMvcResourceParser.getHttpMethodAndName(SpringMvcResourceParser.java:371)
```

The PR correct the point into SpringMvcResourceParser class
