### PR TITLE
- Fixed check for response body schema to cater for catch all media t…

### DIFF
--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/verification/checkers/ActionContentTypeChecker.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/verification/checkers/ActionContentTypeChecker.java
@@ -88,8 +88,9 @@ public class ActionContentTypeChecker implements RamlActionVisitorCheck {
 				} else {
 					//successful response
 					Response targetResponse = target.getResponses().get("200");
-					for (String key : response.getBody().keySet()) {						
-						if (!targetResponse.getBody().containsKey(key)) {
+					for (String key : response.getBody().keySet()) {
+						logger.debug("Processing key {}.", key);
+						if (!targetResponse.getBody().containsKey(key) && !targetResponse.getBody().containsKey(ResourceParser.CATCH_ALL_MEDIA_TYPE)) {
 							issue = new Issue(maxSeverity, location, IssueType.MISSING, RESPONSE_BODY_MISSING, reference.getResource(), reference);
 							RamlCheckerResourceVisitorCoordinator.addIssue(errors, warnings, issue, RESPONSE_BODY_MISSING + " " + key);
 						}


### PR DESCRIPTION
- Fixed check for response body schema to cater for catch all media type. Generator was using catch all media type when building the model for verification if produces attribute was not specified in @RequestMapping annotation. Added check to fix the issue.