### PR TITLE
Enhancements to handling of output file

### DIFF
--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlGenerator.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlGenerator.java
@@ -12,9 +12,18 @@
  */
 package com.phoenixnap.oss.ramlapisync.generation;
 
-import com.phoenixnap.oss.ramlapisync.data.*;
-import com.phoenixnap.oss.ramlapisync.parser.ResourceParser;
-import org.apache.commons.io.FileUtils;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.raml.emitter.RamlEmitter;
 import org.raml.model.DocumentationItem;
 import org.raml.model.Raml;
@@ -24,15 +33,21 @@ import org.raml.parser.utils.Inflector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import com.phoenixnap.oss.ramlapisync.data.ApiBodyMetadata;
+import com.phoenixnap.oss.ramlapisync.data.ApiControllerMetadata;
+import com.phoenixnap.oss.ramlapisync.data.ApiDocumentMetadata;
+import com.phoenixnap.oss.ramlapisync.data.ApiMappingMetadata;
+import com.phoenixnap.oss.ramlapisync.data.ApiParameterMetadata;
+import com.phoenixnap.oss.ramlapisync.parser.ResourceParser;
+
+import org.apache.commons.io.FileUtils;
 
 /**
  * Class containing RAML generation driver. Methods in this class are used to orchestrate the process of extracting

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlGenerator.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlGenerator.java
@@ -410,15 +410,17 @@ public class RamlGenerator {
 	}
 
 	/**
-	 * Checks the path and adds default file name if what was entered ends with a file separator
+	 * Checks the path and adds default file name if what was entered appears to be a directory
 	 *
 	 * @return The absolute path for the RAML file to be saved
 	 */
 	private String preparePath(String path) {
-		// If the path ends with a slash, assume it is a directory and append the default filename
+		// If the path ends with a slash or the system path separator, assume it is a directory
+		// and append the default filename
 		if(path.endsWith("/") || path.endsWith(pathSeparator)) {
 			path += DEFAULT_RAML_FILENAME;
 		}
+		
 		return path;
 	}
 

--- a/springmvc-raml-plugin/README.md
+++ b/springmvc-raml-plugin/README.md
@@ -63,6 +63,12 @@ Then simply include the following code in the POM of the project you wish to gen
 ### outputRamlFilePath
 (required) Relative file path where the RAML document will be saved to
 
+### createPathIfMissing
+(optional, default: false) If this is set to true, we will create the RAML file and directories if they don't exist
+
+### removeOldOutput
+(optional, default: false) If this is set to true, we will empty the output directory before generation occurs
+
 ### javaDocPath
 (optional) Absolute path to a folder which will be used to search for JavaDoc. This folder should contain all source of controllers being scanned. Using root folders for this may increase scanning time. If this is not supplied, the scanner will default to the current project folder
 

--- a/springmvc-raml-plugin/README.md
+++ b/springmvc-raml-plugin/README.md
@@ -64,7 +64,7 @@ Then simply include the following code in the POM of the project you wish to gen
 (required) Relative file path where the RAML document will be saved to
 
 ### createPathIfMissing
-(optional, default: false) If this is set to true, we will create the RAML file and directories if they don't exist
+(optional, default: false) If this is set to true, we will create the path directories if they don't exist
 
 ### removeOldOutput
 (optional, default: false) If this is set to true, we will empty the output directory before generation occurs

--- a/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcRamlApiSyncMojo.java
+++ b/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcRamlApiSyncMojo.java
@@ -118,7 +118,7 @@ public class SpringMvcRamlApiSyncMojo extends CommonApiSyncMojo {
 		String path = project.getBasedir() + this.outputRamlFilePath;
 
 		// If the path ends with a slash, assume it is a directory and append the default filename
-		if(path.endsWith("/") || path.endsWith(pathSeparator) /*path.endsWith("\\")*/) {
+		if(path.endsWith("/") || path.endsWith(pathSeparator)) {
 			path += RamlGenerator.DEFAULT_RAML_FILENAME;
 		}
 

--- a/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcRamlApiSyncMojo.java
+++ b/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcRamlApiSyncMojo.java
@@ -79,8 +79,6 @@ public class SpringMvcRamlApiSyncMojo extends CommonApiSyncMojo {
 		return new Class[] { Controller.class, RestController.class, RequestMapping.class };
 	}
 
-	private static final String pathSeparator = System.getProperty("path.separator");
-
 	protected void generateRaml() throws MojoExecutionException, MojoFailureException, IOException {
 
 		super.prepareRaml();
@@ -115,14 +113,7 @@ public class SpringMvcRamlApiSyncMojo extends CommonApiSyncMojo {
 	 */
 	public String getFullRamlOutputPath() {
 		// must get basedir from project to ensure that correct basedir is used when building from parent
-		String path = project.getBasedir() + this.outputRamlFilePath;
-
-		// If the path ends with a slash, assume it is a directory and append the default filename
-		if(path.endsWith("/") || path.endsWith(pathSeparator)) {
-			path += RamlGenerator.DEFAULT_RAML_FILENAME;
-		}
-
-		return path;
+		return project.getBasedir() + this.outputRamlFilePath;
 	}
 
 	public void execute() throws MojoExecutionException, MojoFailureException {

--- a/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcRamlApiSyncMojo.java
+++ b/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcRamlApiSyncMojo.java
@@ -12,9 +12,13 @@
  */
 package com.phoenixnap.oss.ramlapisync.plugin;
 
-import com.phoenixnap.oss.ramlapisync.generation.RamlGenerator;
-import com.phoenixnap.oss.ramlapisync.parser.ResourceParser;
-import com.phoenixnap.oss.ramlapisync.parser.SpringMvcResourceParser;
+import java.io.File;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Paths;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -25,12 +29,9 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.Paths;
+import com.phoenixnap.oss.ramlapisync.generation.RamlGenerator;
+import com.phoenixnap.oss.ramlapisync.parser.ResourceParser;
+import com.phoenixnap.oss.ramlapisync.parser.SpringMvcResourceParser;
 
 /**
  * Maven Plugin MOJO specific to Spring MVC Projects.
@@ -78,6 +79,8 @@ public class SpringMvcRamlApiSyncMojo extends CommonApiSyncMojo {
 		return new Class[] { Controller.class, RestController.class, RequestMapping.class };
 	}
 
+	private static final String pathSeparator = System.getProperty("path.separator");
+
 	protected void generateRaml() throws MojoExecutionException, MojoFailureException, IOException {
 
 		super.prepareRaml();
@@ -115,7 +118,7 @@ public class SpringMvcRamlApiSyncMojo extends CommonApiSyncMojo {
 		String path = project.getBasedir() + this.outputRamlFilePath;
 
 		// If the path ends with a slash, assume it is a directory and append the default filename
-		if(path.endsWith("/") || path.endsWith("\\")) {
+		if(path.endsWith("/") || path.endsWith(pathSeparator) /*path.endsWith("\\")*/) {
 			path += RamlGenerator.DEFAULT_RAML_FILENAME;
 		}
 


### PR DESCRIPTION
I needed the ability to create the directory for the RAML file during the generation process.  Also added some enhancements to the processing of the output file to make sure a .raml is created and the ability to clean out the output directory before the new file is generated.  Added new configuration parameters so the current behavior is maintained by default.