### PR TITLE
Add uriPrefix parameter during Verifying against Implementation

### DIFF
--- a/springmvc-raml-parser/src/test/java/com/phoenixnap/oss/ramlapisync/generation/RamlGeneratorTest.java
+++ b/springmvc-raml-parser/src/test/java/com/phoenixnap/oss/ramlapisync/generation/RamlGeneratorTest.java
@@ -1,0 +1,83 @@
+package com.phoenixnap.oss.ramlapisync.generation;
+
+import com.phoenixnap.oss.ramlapisync.parser.ResourceParser;
+import com.phoenixnap.oss.ramlapisync.parser.SpringMvcResourceParser;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Test;
+import test.phoenixnap.oss.plugin.naming.testclasses.DoubleLevelPrefixController;
+import test.phoenixnap.oss.plugin.naming.testclasses.TestController;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author tsarnowski
+ */
+public class RamlGeneratorTest {
+
+
+	private RamlGenerator generator = new RamlGenerator();
+
+	@Before
+	public void init(){
+		ResourceParser scanner = new SpringMvcResourceParser(FileUtils.getTempDirectory(), "", ResourceParser.CATCH_ALL_MEDIA_TYPE, false);
+		generator = new RamlGenerator(scanner);
+	}
+
+	@Test
+	public void shouldRemovePrefix(){
+	    //given
+		String uriPrefix = "/base";
+
+	    //when
+		RamlGenerator result = generator.generateRamlForClasses("Test", "testVersion", "/", new Class[]{
+				TestController.class}, null, uriPrefix);
+
+		//then
+		assertFalse("Should not contains '/base' resource", result.getRaml().getResources().containsKey("/base"));
+	}
+
+	@Test
+	public void shouldWorlForEmptyPrefix(){
+		//given
+		String uriPrefix = "";
+
+		//when
+		RamlGenerator result = generator.generateRamlForClasses("Test", "testVersion", "/", new Class[]{
+				TestController.class}, null, uriPrefix);
+
+		//then
+		assertTrue("Should contains '/base' resource", result.getRaml().getResources().containsKey("/base"));
+	}
+
+	@Test
+	public void shouldRemoveTwoLevelsOfResource(){
+		//given
+		String uriPrefix = "/base/v1";
+
+		//when
+		RamlGenerator result = generator.generateRamlForClasses("Test", "testVersion", "/", new Class[]{
+				DoubleLevelPrefixController.class}, null, uriPrefix);
+
+		//then
+		assertFalse("Should not contains '/base' resource", result.getRaml().getResources().containsKey("/base"));
+		assertTrue("Should contains '/simpleMethodAll'", result.getRaml().getResources().containsKey("/simpleMethodAll"));
+		assertTrue("Should contains '/oneParameter'", result.getRaml().getResources().containsKey("/oneParameter"));
+	}
+
+	@Test
+	public void shouldRemoveLevelWithEmptyResources(){
+		//given
+		String uriPrefix = "/base/v1/simpleMethodAll";
+
+		//when
+		RamlGenerator result = generator.generateRamlForClasses("Test", "testVersion", "/", new Class[]{
+				DoubleLevelPrefixController.class}, null, uriPrefix);
+
+		//then
+		assertFalse("Should not contains '/base' resource", result.getRaml().getResources().containsKey("/base"));
+		assertTrue("Should contains '/oneParameter'", result.getRaml().getResources().containsKey("/oneParameter"));
+	}
+
+}

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/RamlVerifierTest.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/RamlVerifierTest.java
@@ -10,30 +10,6 @@
 package test.phoenixnap.oss.plugin.naming;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Collections;
-import java.util.Iterator;
-
-import org.junit.Test;
-import org.raml.model.Raml;
-
-import test.phoenixnap.oss.plugin.naming.testclasses.ContentTypeTestController;
-import test.phoenixnap.oss.plugin.naming.testclasses.MultiContentTypeTestController;
-import test.phoenixnap.oss.plugin.naming.testclasses.ParamTestController;
-import test.phoenixnap.oss.plugin.naming.testclasses.ParamTestControllerDowngradeToWarning;
-import test.phoenixnap.oss.plugin.naming.testclasses.ParamTestControllerPostMissing;
-import test.phoenixnap.oss.plugin.naming.testclasses.ParamTestControllerPostWarning;
-import test.phoenixnap.oss.plugin.naming.testclasses.ResponseBodyTestController;
-import test.phoenixnap.oss.plugin.naming.testclasses.ResponseBodyTestControllerError;
-import test.phoenixnap.oss.plugin.naming.testclasses.SecondVerifierTestController;
-import test.phoenixnap.oss.plugin.naming.testclasses.StyleCheckResourceDuplicateCommand;
-import test.phoenixnap.oss.plugin.naming.testclasses.StyleCheckResourceDuplicateCommandSecond;
-import test.phoenixnap.oss.plugin.naming.testclasses.ThirdVerifierTestController;
-import test.phoenixnap.oss.plugin.naming.testclasses.VerifierTestController;
-
 import com.phoenixnap.oss.ramlapisync.generation.RamlGenerator;
 import com.phoenixnap.oss.ramlapisync.generation.RamlVerifier;
 import com.phoenixnap.oss.ramlapisync.parser.ResourceParser;
@@ -42,11 +18,15 @@ import com.phoenixnap.oss.ramlapisync.verification.Issue;
 import com.phoenixnap.oss.ramlapisync.verification.IssueLocation;
 import com.phoenixnap.oss.ramlapisync.verification.IssueSeverity;
 import com.phoenixnap.oss.ramlapisync.verification.IssueType;
-import com.phoenixnap.oss.ramlapisync.verification.checkers.ActionContentTypeChecker;
-import com.phoenixnap.oss.ramlapisync.verification.checkers.ActionExistenceChecker;
-import com.phoenixnap.oss.ramlapisync.verification.checkers.ActionQueryParameterChecker;
-import com.phoenixnap.oss.ramlapisync.verification.checkers.ActionResponseBodySchemaChecker;
-import com.phoenixnap.oss.ramlapisync.verification.checkers.ResourceExistenceChecker;
+import com.phoenixnap.oss.ramlapisync.verification.checkers.*;
+import org.junit.Test;
+import org.raml.model.Raml;
+import test.phoenixnap.oss.plugin.naming.testclasses.*;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
 
 
 
@@ -68,7 +48,7 @@ public class RamlVerifierTest {
 	public void test_ResourceExistenceChecker_Success() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-simple.raml");
 		Class<?>[] classesToGenerate = new Class[] { VerifierTestController.class, SecondVerifierTestController.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.singletonList(new ResourceExistenceChecker()), null, null);
 		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
@@ -81,7 +61,7 @@ public class RamlVerifierTest {
 	public void test_ResourceExistenceChecker_DuplicateCommand() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-duplicatecommand.raml");
 		Class<?>[] classesToGenerate = new Class[] { StyleCheckResourceDuplicateCommand.class, StyleCheckResourceDuplicateCommandSecond.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.singletonList(new ResourceExistenceChecker()), null, null);
 		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
@@ -94,7 +74,7 @@ public class RamlVerifierTest {
 	public void test_ActionQueryParameterChecker_Success() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-queryparam-success.raml");
 		Class<?>[] classesToGenerate = new Class[] { ParamTestController.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionQueryParameterChecker()), null);
 		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
@@ -107,7 +87,7 @@ public class RamlVerifierTest {
 	public void test_ActionContentTypeChecker_Success() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-contenttype-success.raml");
 		Class<?>[] classesToGenerate = new Class[] { ContentTypeTestController.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionContentTypeChecker()), null);
 		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
@@ -120,7 +100,7 @@ public class RamlVerifierTest {
 	public void test_ActionMultiContentTypeChecker_Success() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-multicontenttype-success.raml");
 		Class<?>[] classesToGenerate = new Class[] { MultiContentTypeTestController.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionContentTypeChecker()), null);
 		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
@@ -133,7 +113,7 @@ public class RamlVerifierTest {
 	public void test_ActionResponseBodySchemaChecker_Success() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-responsebody-success.raml");
 		Class<?>[] classesToGenerate = new Class[] { ResponseBodyTestController.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionResponseBodySchemaChecker()), null);
 		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
@@ -146,7 +126,7 @@ public class RamlVerifierTest {
 	public void test_ActionContentTypeChecker_WarningDifferentType() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-responsebody-differenttype.raml");
 		Class<?>[] classesToGenerate = new Class[] { ResponseBodyTestController.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionResponseBodySchemaChecker()), null);
 		assertFalse("Check that there are errors", verifier.hasErrors());
@@ -163,7 +143,7 @@ public class RamlVerifierTest {
 	public void test_ActionContentTypeChecker_ErrorMissingFieldInRaml() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-responsebody-missing.raml");
 		Class<?>[] classesToGenerate = new Class[] { ResponseBodyTestController.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionResponseBodySchemaChecker()), null);
 		assertTrue("Check that there are errors", verifier.hasErrors());
@@ -180,7 +160,7 @@ public class RamlVerifierTest {
 	public void test_ActionContentTypeChecker_ErrorMissingFieldInSource() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-responsebody-success.raml");
 		Class<?>[] classesToGenerate = new Class[] { ResponseBodyTestControllerError.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionResponseBodySchemaChecker()), null);
 		assertTrue("Check that there are errors", verifier.hasErrors());
@@ -197,7 +177,7 @@ public class RamlVerifierTest {
 	public void test_ActionQueryParameterChecker_SuccessWithPostWarning() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-queryparam-success.raml");
 		Class<?>[] classesToGenerate = new Class[] { ParamTestController.class, ParamTestControllerPostWarning.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionQueryParameterChecker()), null);
 		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
@@ -215,7 +195,7 @@ public class RamlVerifierTest {
 	public void test_ActionQueryParameterChecker_MissingParamsInContract() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-queryparam-missing.raml");
 		Class<?>[] classesToGenerate = new Class[] { ParamTestController.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionQueryParameterChecker()), null);
 		assertTrue("Check that there are errors", verifier.hasErrors());
@@ -236,7 +216,7 @@ public class RamlVerifierTest {
 	public void test_ActionQueryParameterChecker_MissingParamsInSource() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-queryparam-success.raml");
 		Class<?>[] classesToGenerate = new Class[] { ParamTestController.class, ParamTestControllerPostMissing.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionQueryParameterChecker()), null);
 		assertTrue("Check that there are errors", verifier.hasErrors());
@@ -254,7 +234,7 @@ public class RamlVerifierTest {
 	public void test_ActionQueryParameterChecker_MissingParamsNotRequiredDowngradeToWarning() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-queryparam-success.raml");
 		Class<?>[] classesToGenerate = new Class[] { ParamTestController.class, ParamTestControllerDowngradeToWarning.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionQueryParameterChecker()), null);
 		assertTrue("Check that there are errors", verifier.hasErrors());
@@ -277,7 +257,7 @@ public class RamlVerifierTest {
 	public void test_ActionExistenceChecker_Success() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-simple.raml");
 		Class<?>[] classesToGenerate = new Class[] { VerifierTestController.class, SecondVerifierTestController.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), null, Collections.singletonList(new ActionExistenceChecker()));
 		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
@@ -290,7 +270,7 @@ public class RamlVerifierTest {
 	public void test_ActionExistenceChecker_MissingAndExtraActions() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-actions-missing.raml");
 		Class<?>[] classesToGenerate = new Class[] { VerifierTestController.class, SecondVerifierTestController.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), null, Collections.singletonList(new ActionExistenceChecker()));
 		assertTrue("Check that there are no errors and implementation matches raml", verifier.hasErrors());
@@ -312,7 +292,7 @@ public class RamlVerifierTest {
 	public void test_ResourceExistenceChecker_MissingResourceInRaml() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-simple.raml");
 		Class<?>[] classesToGenerate = new Class[] { VerifierTestController.class, SecondVerifierTestController.class, ThirdVerifierTestController.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.singletonList(new ResourceExistenceChecker()), null, null);
 		assertFalse("Check that there are no errors since the missing resource will get marked as a warning", verifier.hasErrors());
@@ -328,7 +308,7 @@ public class RamlVerifierTest {
 	public void test_ResourceExistenceChecker_MissingResourceInImplementation() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-simple.raml");
 		Class<?>[] classesToGenerate = new Class[] { VerifierTestController.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.singletonList(new ResourceExistenceChecker()), null, null);
 		assertTrue("Check that there are errors since there is part of our contract not implemented", verifier.hasErrors());
@@ -344,7 +324,7 @@ public class RamlVerifierTest {
 	public void test_ResourceExistenceChecker_UriParamAlwaysWarning() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-uriparam.raml");
 		Class<?>[] classesToGenerate = new Class[] { SecondVerifierTestController.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet(), null).getRaml();
 
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.singletonList(new ResourceExistenceChecker()), null, null);
 		assertFalse("Check that there are no errors", verifier.hasErrors());

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/testclasses/DoubleLevelPrefixController.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/testclasses/DoubleLevelPrefixController.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package test.phoenixnap.oss.plugin.naming.testclasses;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/base/v1")
+public class DoubleLevelPrefixController {
+
+	public void unannotatedMethod() {
+
+	}
+
+	@RequestMapping("/simpleMethodAll")
+	public String simpleMethodAllHttpMethods() {
+		return null;
+	}
+
+	@RequestMapping(value = "/oneParameter", method = { RequestMethod.POST })
+	public String postMethodSimpleParameter(@RequestParam String param1) {
+		return null;
+	}
+}

--- a/springmvc-raml-plugin/README.md
+++ b/springmvc-raml-plugin/README.md
@@ -128,6 +128,7 @@ Then simply include the following code in the POM of the project you wish to gen
 	<dependencyPackagesList>
 	   <param>com.package.in.dependency.jar.to.include</param>
 	</dependencyPackagesList>
+	<uriPrefix>/api</uriPrefix>
   </configuration>
   <executions>
     <execution>
@@ -185,6 +186,9 @@ Then simply include the following code in the POM of the project you wish to gen
 
 ### logErrors
 (optional, default: false) Flag that will enable or disable logging of error level Issues to standard out if found
+
+### uriPrefix
+(optional, defaul: "") If set skip given prefix from all URIs during checking agains contract
 
 ## Usage 3 - Generating SpringMVC Server Endpoints from a RAML file
 

--- a/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcRamlApiSyncMojo.java
+++ b/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcRamlApiSyncMojo.java
@@ -101,7 +101,7 @@ public class SpringMvcRamlApiSyncMojo extends CommonApiSyncMojo {
 		RamlGenerator ramlGenerator = new RamlGenerator(scanner);
 		// Process the classes selected and build Raml model
 		ramlGenerator
-				.generateRamlForClasses(project.getArtifactId(), version, restBasePath, classArray, this.documents);
+				.generateRamlForClasses(project.getArtifactId(), version, restBasePath, classArray, this.documents, null);
 
 		// Extract RAML as a string and save to file
 		ramlGenerator.outputRamlToFile(this.getFullRamlOutputPath(), createPathIfMissing, removeOldOutput);

--- a/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcRamlVerifierMojo.java
+++ b/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcRamlVerifierMojo.java
@@ -12,25 +12,6 @@
  */
 package com.phoenixnap.oss.ramlapisync.plugin;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.raml.model.Raml;
-import org.springframework.stereotype.Controller;
-import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.phoenixnap.oss.ramlapisync.generation.RamlGenerator;
 import com.phoenixnap.oss.ramlapisync.generation.RamlVerifier;
 import com.phoenixnap.oss.ramlapisync.parser.ResourceParser;
@@ -47,6 +28,24 @@ import com.phoenixnap.oss.ramlapisync.verification.checkers.ActionContentTypeChe
 import com.phoenixnap.oss.ramlapisync.verification.checkers.ActionExistenceChecker;
 import com.phoenixnap.oss.ramlapisync.verification.checkers.ActionQueryParameterChecker;
 import com.phoenixnap.oss.ramlapisync.verification.checkers.ResourceExistenceChecker;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.raml.model.Raml;
+import org.springframework.stereotype.Controller;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Maven Plugin MOJO specific to verification of RAML from implementations in Spring MVC Projects.
@@ -132,7 +131,10 @@ public class SpringMvcRamlVerifierMojo extends CommonApiSyncMojo {
 	 */
 	@Parameter(required = false, readonly = true, defaultValue = "true")
 	protected Boolean logErrors;
-	
+
+	@Parameter(required = false, readonly = true, defaultValue = "")
+	protected String uriPrefix;
+
 	@SuppressWarnings("unchecked")
 	@Override
 	protected Class<? extends Annotation>[] getSupportedClassAnnotations() {
@@ -159,7 +161,7 @@ public class SpringMvcRamlVerifierMojo extends CommonApiSyncMojo {
 		ResourceParser scanner = new SpringMvcResourceParser(targetPath, version, ResourceParser.CATCH_ALL_MEDIA_TYPE, false);
 		RamlGenerator ramlGenerator = new RamlGenerator(scanner);
 		// Process the classes selected and build Raml model
-		ramlGenerator.generateRamlForClasses(project.getArtifactId(), version, "/", classArray, this.documents);
+		ramlGenerator.generateRamlForClasses(project.getArtifactId(), version, "/", classArray, this.documents, uriPrefix);
 		Raml implementedRaml = ramlGenerator.getRaml();
 		
 		List<RamlChecker> checkers = new ArrayList<>();


### PR DESCRIPTION
During generating code from RAML file it is posible to specify
baseUri which is used as prefix for all generated resources.
But this prefix breaks verificaiton against implementation
so add parameter which can compensate baseUri during code
generation.