### PR TITLE
Fix issue #53 - Append response schema validation checking

### DIFF
--- a/springmvc-raml-plugin/README.md
+++ b/springmvc-raml-plugin/README.md
@@ -126,6 +126,7 @@ Then simply include the following code in the POM of the project you wish to gen
 	<checkForSchemaInSuccessfulResponseBody>true</checkForSchemaInSuccessfulResponseBody>
 	<checkForSchemaInRequestBody>true</checkForSchemaInRequestBody>
 	<checkForDefinitionOf404ResponseInGetRequest>true</checkForDefinitionOf404ResponseInGetRequest>
+	<checkForResponseBodySchema>true</checkForResponseBodySchema>
 	<breakBuildOnWarnings>false</breakBuildOnWarnings>
     <logWarnings>true</logWarnings>
     <logErrors>true</logErrors>	
@@ -196,6 +197,9 @@ Then simply include the following code in the POM of the project you wish to gen
 
 ### checkForDefinitionOfErrorCodes
 (optional, default: false) Flag that will enable or disable checks for 400 and 500 error codes in certain verbs (PUT, POST, PATCH for 400 & All verbs for 500)
+
+### checkForResponseBodySchema
+(optional, default: false) Flag that will enable or disable response body schema validation against implementation
 
 ### ignoredList
 (optional, default: empty) If classes or packages are included in this list, they will not be included in the generated model

--- a/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcRamlVerifierMojo.java
+++ b/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcRamlVerifierMojo.java
@@ -148,7 +148,13 @@ public class SpringMvcRamlVerifierMojo extends CommonApiSyncMojo {
 	 */
 	@Parameter(required = false, readonly = true, defaultValue = "false")
 	protected Boolean checkForDefinitionOf404ResponseInGetRequest;
-		
+
+	/**
+	 * Flag that will enable or disable checks for response body schema
+	 */
+	@Parameter(required = false, readonly = true, defaultValue = "false")
+	protected Boolean checkForResponseBodySchema;
+
 	/**
 	 * Flag that will enable or disable braking of the build if Warnings are found
 	 */
@@ -215,8 +221,9 @@ public class SpringMvcRamlVerifierMojo extends CommonApiSyncMojo {
 			if (checkForActionContentType) {
 				actionCheckers.add(new ActionContentTypeChecker());
 			}
-
-			actionCheckers.add(new ActionResponseBodySchemaChecker());
+			if(checkForResponseBodySchema) {
+				actionCheckers.add(new ActionResponseBodySchemaChecker());
+			}
 		}
 		
 		List<RamlStyleChecker> styleCheckers = new ArrayList<>();

--- a/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcRamlVerifierMojo.java
+++ b/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcRamlVerifierMojo.java
@@ -12,15 +12,17 @@
  */
 package com.phoenixnap.oss.ramlapisync.plugin;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-
+import com.phoenixnap.oss.ramlapisync.generation.RamlGenerator;
+import com.phoenixnap.oss.ramlapisync.generation.RamlVerifier;
+import com.phoenixnap.oss.ramlapisync.parser.ResourceParser;
+import com.phoenixnap.oss.ramlapisync.parser.SpringMvcResourceParser;
+import com.phoenixnap.oss.ramlapisync.style.RamlStyleChecker;
+import com.phoenixnap.oss.ramlapisync.style.checkers.*;
+import com.phoenixnap.oss.ramlapisync.verification.Issue;
+import com.phoenixnap.oss.ramlapisync.verification.RamlActionVisitorCheck;
+import com.phoenixnap.oss.ramlapisync.verification.RamlChecker;
+import com.phoenixnap.oss.ramlapisync.verification.RamlResourceVisitorCheck;
+import com.phoenixnap.oss.ramlapisync.verification.checkers.*;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -35,25 +37,14 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.phoenixnap.oss.ramlapisync.generation.RamlGenerator;
-import com.phoenixnap.oss.ramlapisync.generation.RamlVerifier;
-import com.phoenixnap.oss.ramlapisync.parser.ResourceParser;
-import com.phoenixnap.oss.ramlapisync.parser.SpringMvcResourceParser;
-import com.phoenixnap.oss.ramlapisync.style.RamlStyleChecker;
-import com.phoenixnap.oss.ramlapisync.style.checkers.ActionSecurityResponseChecker;
-import com.phoenixnap.oss.ramlapisync.style.checkers.RequestBodySchemaStyleChecker;
-import com.phoenixnap.oss.ramlapisync.style.checkers.ResourceCollectionPluralisationChecker;
-import com.phoenixnap.oss.ramlapisync.style.checkers.ResourceUrlStyleChecker;
-import com.phoenixnap.oss.ramlapisync.style.checkers.ResponseBodySchemaStyleChecker;
-import com.phoenixnap.oss.ramlapisync.style.checkers.ResponseCodeDefinitionStyleChecker;
-import com.phoenixnap.oss.ramlapisync.verification.Issue;
-import com.phoenixnap.oss.ramlapisync.verification.RamlActionVisitorCheck;
-import com.phoenixnap.oss.ramlapisync.verification.RamlChecker;
-import com.phoenixnap.oss.ramlapisync.verification.RamlResourceVisitorCheck;
-import com.phoenixnap.oss.ramlapisync.verification.checkers.ActionContentTypeChecker;
-import com.phoenixnap.oss.ramlapisync.verification.checkers.ActionExistenceChecker;
-import com.phoenixnap.oss.ramlapisync.verification.checkers.ActionQueryParameterChecker;
-import com.phoenixnap.oss.ramlapisync.verification.checkers.ResourceExistenceChecker;
+import java.io.File;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Maven Plugin MOJO specific to verification of RAML from implementations in Spring MVC Projects.
@@ -224,10 +215,9 @@ public class SpringMvcRamlVerifierMojo extends CommonApiSyncMojo {
 			if (checkForActionContentType) {
 				actionCheckers.add(new ActionContentTypeChecker());
 			}
+
+			actionCheckers.add(new ActionResponseBodySchemaChecker());
 		}
-		
-		
-		
 		
 		List<RamlStyleChecker> styleCheckers = new ArrayList<>();
 		


### PR DESCRIPTION
Checker wasn`t used.
I thing it shuld be always used when verifing implementation,
so there is no option to change this particural checking.
Fixes #53.