### PR TITLE
Support for FeignClient generation (#94)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
 		<ramlparser.version>0.8.13</ramlparser.version>
 		<reflections.version>0.9.10</reflections.version>
 		<javaparser.version>2.4.0</javaparser.version>
+		<feign.client.version>1.1.6.RELEASE</feign.client.version>
 	</properties>
   
 	<build>

--- a/springmvc-raml-parser/pom.xml
+++ b/springmvc-raml-parser/pom.xml
@@ -103,6 +103,19 @@
             <artifactId>jsonschema2pojo-core</artifactId>
         </dependency>
 		
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-feign</artifactId>
+			<version>${feign.client.version}</version>
+			<optional>true</optional>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
 		
 		<!-- Test Dependencies -->
 		

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/SpringFeignClientInterfaceRule.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/SpringFeignClientInterfaceRule.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.phoenixnap.oss.ramlapisync.generation.rules;
+
+import org.springframework.cloud.netflix.feign.FeignClient;
+
+import com.phoenixnap.oss.ramlapisync.generation.rules.spring.SpringFeignClientInterfaceDecoratorRule;
+
+/**
+ * A code generation Rule that provides a standalone {@link FeignClient}.
+ * The goal is to generate code that does not have to be manually extended by the user.
+ * <br/>
+ * A raml endpoint called /people exposed on http://somehost:8080 for example would lead to the 
+ * following interface:
+ *
+ * <pre class="code">
+ * {@literal @}FeignClient(url = "http://somehost:8080/people", name = "feignClientPeople")
+ * interface PeopleFeignClient {
+ * 
+ *     {@literal @}RequestMapping(value="", method=RequestMethod.GET)
+ *     ResponseEntity{@literal <}com.gen.test.model.People> getPeople();
+ * }
+ * </pre>
+ *
+ * Now all the user has to do is to autowire this interface.
+ * This way he can invoke remote endpoint.
+ *
+ * @author Aleksandar Stojsavljevic
+ * @since 0.8.6
+ */
+public class SpringFeignClientInterfaceRule extends SpringFeignClientInterfaceDecoratorRule {
+
+}

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/basic/SpringFeignClientInterfaceDeclarationRule.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/basic/SpringFeignClientInterfaceDeclarationRule.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.phoenixnap.oss.ramlapisync.generation.rules.basic;
+
+import com.phoenixnap.oss.ramlapisync.data.ApiResourceMetadata;
+import com.phoenixnap.oss.ramlapisync.generation.rules.Rule;
+import com.sun.codemodel.JClassAlreadyExistsException;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JPackage;
+
+/**
+ * Generates an interface declaration based on the controller name in ApiControllerMetadata.
+ * <br/>
+ * INPUT:
+ * <pre class="code">
+ * #%RAML 0.8
+ * title: myapi
+ * mediaType: application/json
+ * baseUri: /
+ * /base:
+ * </pre>
+ *
+ * OUTPUT:
+ * <pre class="code">
+ * public interface BaseClient {
+ *
+ * }
+ * </pre>
+ *
+ * @author Aleksandar Stojsavljevic
+ * @since 0.8.6
+ */
+public class SpringFeignClientInterfaceDeclarationRule implements Rule<JPackage,JDefinedClass, ApiResourceMetadata> {
+
+    @Override
+    public JDefinedClass apply(ApiResourceMetadata controllerMetadata, JPackage generatableType) {
+    	
+        String controllerClassName = controllerMetadata.getResourceName().concat("Client");
+        JDefinedClass definedClass;
+        try {
+            definedClass = generatableType._interface(controllerClassName);
+        } catch (JClassAlreadyExistsException e1) {
+            definedClass = generatableType._getClass(controllerClassName);
+        }
+        return definedClass;
+    }
+
+}

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringFeignClientClassAnnotationRule.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringFeignClientClassAnnotationRule.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.phoenixnap.oss.ramlapisync.generation.rules.spring;
+
+import org.springframework.cloud.netflix.feign.FeignClient;
+
+import com.phoenixnap.oss.ramlapisync.data.ApiResourceMetadata;
+import com.phoenixnap.oss.ramlapisync.generation.rules.Rule;
+import com.sun.codemodel.JAnnotationUse;
+import com.sun.codemodel.JDefinedClass;
+
+/**
+ * Adds a {@literal @}FeignClient annotation at class level.
+ * The "url" of the {@literal @}FeignClient is the endpoint url from the ApiControllerMetadata instance.
+ * <br/>
+ * 
+ * INPUT:
+ * <pre class="code">
+ * #%RAML 0.8
+ * title: myapi
+ * mediaType: application/json
+ * baseUri: /api
+ * /base:
+ *   get:
+ * </pre>
+ * 
+ * OUTPUT:
+ * <pre class="code">
+ * {@literal @}FeignClient(url = "/api/base", name = "baseClient")
+ * </pre>
+ * 
+ * @author Aleksandar Stojsavljevic
+ * @since 0.8.6
+ */
+public class SpringFeignClientClassAnnotationRule implements Rule<JDefinedClass, JAnnotationUse, ApiResourceMetadata> {
+    @Override
+    public JAnnotationUse apply(ApiResourceMetadata controllerMetadata, JDefinedClass generatableType) {
+        JAnnotationUse feignClient = generatableType.annotate(FeignClient.class);
+        
+        feignClient.param("url", controllerMetadata.getControllerUrl());
+        feignClient.param("name", getClientName(controllerMetadata));
+
+        return feignClient;
+    }
+    
+    private String getClientName(ApiResourceMetadata controllerMetadata) {
+    	String name = controllerMetadata.getResourceName();
+    	
+    	if (name == null || name.length() == 0) {
+            return "Client";
+        }
+        return name.substring(0, 1).toLowerCase() + name.substring(1)  + "Client";
+    }
+}

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringFeignClientInterfaceDecoratorRule.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringFeignClientInterfaceDecoratorRule.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.phoenixnap.oss.ramlapisync.generation.rules.spring;
+
+import org.springframework.cloud.netflix.feign.FeignClient;
+
+import com.phoenixnap.oss.ramlapisync.data.ApiResourceMetadata;
+import com.phoenixnap.oss.ramlapisync.generation.rules.GenericJavaClassRule;
+import com.phoenixnap.oss.ramlapisync.generation.rules.Rule;
+import com.phoenixnap.oss.ramlapisync.generation.rules.basic.ClassCommentRule;
+import com.phoenixnap.oss.ramlapisync.generation.rules.basic.ControllerMethodSignatureRule;
+import com.phoenixnap.oss.ramlapisync.generation.rules.basic.SpringFeignClientInterfaceDeclarationRule;
+import com.phoenixnap.oss.ramlapisync.generation.rules.basic.MethodCommentRule;
+import com.phoenixnap.oss.ramlapisync.generation.rules.basic.PackageRule;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+
+/**
+ * A code generation Rule that provides a standalone {@link FeignClient}.
+ * The goal is to generate code that does not have to be manually extended by the user.
+ * <br/>
+ * A raml endpoint called /people exposed on http://somehost:8080 for example would lead to the 
+ * following interface:
+ *
+ * <pre class="code">
+ * {@literal @}FeignClient(url = "http://somehost:8080/people", name = "feignClientPeople")
+ * interface PeopleFeignClient {
+ * 
+ *     {@literal @}RequestMapping(value="", method=RequestMethod.GET)
+ *     ResponseEntity{@literal <}com.gen.test.model.People> getPeople();
+ * }
+ * </pre>
+ *
+ * Now all the user has to do is to autowire this interface.
+ * This way he can invoke remote endpoint.
+ *
+ * @author Aleksandar Stojsavljevic
+ * @since 0.8.6
+ */
+public class SpringFeignClientInterfaceDecoratorRule implements Rule<JCodeModel, JDefinedClass, ApiResourceMetadata> {
+	
+	@Override
+    public final JDefinedClass apply(ApiResourceMetadata metadata, JCodeModel generatableType) {
+
+        GenericJavaClassRule generator = new GenericJavaClassRule()
+                .setPackageRule(new PackageRule())
+                .setClassCommentRule(new ClassCommentRule())
+                .addClassAnnotationRule(new SpringFeignClientClassAnnotationRule())
+                .setClassRule(new SpringFeignClientInterfaceDeclarationRule())
+                .setMethodCommentRule(new MethodCommentRule())
+                .addMethodAnnotationRule(new SpringRequestMappingMethodAnnotationRule())
+                .setMethodSignatureRule(new ControllerMethodSignatureRule(
+                        new SpringFeignClientResponseTypeRule(),
+                        new SpringMethodParamsRule())
+                );
+        return generator.apply(metadata, generatableType);
+    }
+}

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringFeignClientResponseTypeRule.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringFeignClientResponseTypeRule.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.phoenixnap.oss.ramlapisync.generation.rules.spring;
+
+import static com.phoenixnap.oss.ramlapisync.generation.CodeModelHelper.findFirstClassBySimpleName;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+
+import com.phoenixnap.oss.ramlapisync.data.ApiBodyMetadata;
+import com.phoenixnap.oss.ramlapisync.data.ApiActionMetadata;
+import com.phoenixnap.oss.ramlapisync.generation.rules.Rule;
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JType;
+
+/**
+ * Creates a {@link ResponseEntity} as a return type for an endpoint.
+ * If the endpoint declares a response body the first type of the response body will used as return type instead.
+ * <br/>
+ * INPUT:
+ * <pre class="code">
+ * #%RAML 0.8
+ * title: myapi
+ * mediaType: application/json
+ * baseUri: /
+ *
+ * /base:
+ *   get:
+ *   /{id}:
+ *     get:
+ *       responses:
+ *         200:
+ *           body:
+ *             application/json:
+ *               schema: NamedResponseType
+ *               ...
+ * </pre>
+ * OUTPUT:
+ * <pre class="code">
+ * ResponseEntity{@literal <}NamedResponseType>
+ * </pre>
+ * OR:
+ * <pre class="code">
+ * ResponseEntity{@literal <}List{@literal <}NamedResponseType>> (if the NamedResponseType is an "array")
+ * </pre>
+ * 
+ * @author Aleksandar Stojsavljevic
+ * @since 0.8.6
+ */
+public class SpringFeignClientResponseTypeRule implements Rule<JDefinedClass, JType, ApiActionMetadata> {
+
+    @Override
+    public JType apply(ApiActionMetadata endpointMetadata, JDefinedClass generatableType) {
+        JClass responseEntity = generatableType.owner().ref(ResponseEntity.class);
+        if (!endpointMetadata.getResponseBody().isEmpty()) {
+            ApiBodyMetadata apiBodyMetadata = endpointMetadata.getResponseBody().values().iterator().next();
+            JClass genericType = findFirstClassBySimpleName(apiBodyMetadata.getCodeModel(), apiBodyMetadata.getName());
+            if (apiBodyMetadata.isArray()) {
+                JClass arrayType = generatableType.owner().ref(List.class);
+                responseEntity = responseEntity.narrow(arrayType.narrow(genericType));
+            } else {
+                responseEntity = responseEntity.narrow(genericType);
+            }
+        }
+        return responseEntity;
+    }
+}

--- a/springmvc-raml-parser/src/test/java/com/phoenixnap/oss/ramlapisync/generation/rules/SpringFeignClientRulesTest.java
+++ b/springmvc-raml-parser/src/test/java/com/phoenixnap/oss/ramlapisync/generation/rules/SpringFeignClientRulesTest.java
@@ -1,0 +1,32 @@
+package com.phoenixnap.oss.ramlapisync.generation.rules;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.phoenixnap.oss.ramlapisync.data.ApiResourceMetadata;
+import com.phoenixnap.oss.ramlapisync.generation.RamlParser;
+import com.phoenixnap.oss.ramlapisync.generation.rules.spring.SpringFeignClientInterfaceDecoratorRule;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+
+/**
+ * @author Aleksandar Stojsavljevic
+ * @since 0.8.6
+ */
+public class SpringFeignClientRulesTest extends AbstractRuleTestBase {
+
+    private Rule<JCodeModel, JDefinedClass, ApiResourceMetadata> rule;
+    
+    @BeforeClass
+	public static void initRaml() {
+		AbstractRuleTestBase.RAML = RamlParser.loadRamlFromFile("test-feign-client.raml");
+	}
+    
+    @Test
+    public void applySpring4SpringTemplateClient_shouldCreate_validCode() throws Exception {
+        rule = new SpringFeignClientInterfaceDecoratorRule();
+        rule.apply(getControllerMetadata(), jCodeModel);
+        verifyGeneratedCode("SongClient");
+    }
+    
+}

--- a/springmvc-raml-parser/src/test/resources/rules/SongClient.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/SongClient.java.txt
@@ -1,0 +1,69 @@
+-----------------------------------com.gen.test.SongClient.java-----------------------------------
+
+package com.gen.test;
+
+import java.util.List;
+import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+
+/**
+ * Songs services
+ * (Generated with springmvc-raml-parser v.${project.version})
+ * 
+ */
+@FeignClient(url = "/api/songs", name = "songClient")
+public interface SongClient {
+
+
+    /**
+     * Gets all songs
+     * 
+     */
+    @RequestMapping(value = "", method = RequestMethod.GET)
+    public ResponseEntity<List<com.gen.test.model.Song>> getSongs();
+
+    /**
+     * Creates new song
+     * 
+     */
+    @RequestMapping(value = "", method = RequestMethod.POST)
+    public ResponseEntity<com.gen.test.model.Song> createSong(
+        @javax.validation.Valid
+        @org.springframework.web.bind.annotation.RequestBody
+        com.gen.test.model.Song song);
+
+    /**
+     * Gets song by id
+     * 
+     */
+    @RequestMapping(value = "/{songId}", method = RequestMethod.GET)
+    public ResponseEntity<com.gen.test.model.Song> getSongById(
+        @PathVariable
+        String songId);
+
+    /**
+     * Updates song
+     * 
+     */
+    @RequestMapping(value = "/{songId}", method = RequestMethod.PUT)
+    public ResponseEntity<com.gen.test.model.Song> updateSongById(
+        @PathVariable
+        String songId,
+        @javax.validation.Valid
+        @org.springframework.web.bind.annotation.RequestBody
+        com.gen.test.model.Song song);
+
+    /**
+     * Deletes song
+     * 
+     */
+    @RequestMapping(value = "/{songId}", method = RequestMethod.DELETE)
+    public ResponseEntity deleteSongById(
+        @PathVariable
+        String songId);
+
+}

--- a/springmvc-raml-parser/src/test/resources/test-feign-client.raml
+++ b/springmvc-raml-parser/src/test/resources/test-feign-client.raml
@@ -1,0 +1,154 @@
+#%RAML 0.8
+title: Song API
+version: v1
+baseUri: http://abc:8000
+schemas:
+  - song: |
+      {
+        "type": "object",
+        "id": "song",
+        "$schema": "song",
+        "properties": {
+          "songId": {
+            "type": "string"
+          },
+          "songTitle": {
+            "type": "string"
+          },
+          "artist": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "songId",
+          "songTitle",
+          "artist"
+        ]
+      }
+  - songs: |
+      {
+        "type": "array",
+        "id": "songs",
+        "$schema": "songs",
+        "properties" : {
+            "songs" : {
+                "type" : "array",
+                "items": {
+                  "properties": {
+                    "songId": {
+                      "type": "string"
+                    },
+                    "songTitle": {
+                      "type": "string"
+                    },
+                    "artist": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "songId",
+                    "songTitle",
+                    "artist"
+                  ]
+                }
+            }
+        }
+      }
+/songs:
+  displayName: Songs
+  description: Songs services
+  get:
+    description: Gets all songs
+    responses:
+      200:
+        description: Successful Response
+        body:
+          application/json:
+            schema: songs
+            example: |
+              [
+                {
+                  "songId": "0594ad16-e9ab-45eb-b7f3-490c955034a6",
+                  "songTitle": "Into The Night",
+                  "artist": "Carlos Santana"
+                },
+                {
+                  "songId": "7fc8d30e-4fd4-4b36-b5d2-06010110150d",
+                  "songTitle": "People Are Strange",
+                  "artist": "The Doors"
+                }
+              ]
+  post:
+    description: Creates new song
+    body:
+      application/json:
+        schema: song
+        example: |
+          {
+            "songId": "2ab846ba-75b6-4b1e-aa3c-937492cd1982",
+            "songTitle": "Insane In The Brain",
+            "artist": "Cypress Hill"
+          }
+    responses:
+      200:
+        description: Successful Response
+        body:
+          application/json:
+            schema: song
+            example: |
+              {
+                "songId": "2ab846ba-75b6-4b1e-aa3c-937492cd1982",
+                "songTitle": "Insane In The Brain",
+                "artist": "Cypress Hill"
+              }
+  /{songId}:
+    uriParameters:
+      songId:
+        description: Unique id of song
+        example: "2ab846ba-75b6-4b1e-aa3c-937492cd1982"
+        type: string
+        required: true
+    displayName: Song
+    description: Some song
+    get:
+      description: Gets song by id
+      responses:
+        200:
+          description: Successful Response
+          body:
+            application/json:
+              schema: song
+              example: |
+                {
+                  "songId": "2ab846ba-75b6-4b1e-aa3c-937492cd1982",
+                  "songTitle": "Insane In The Brain",
+                  "artist": "Cypress Hill"
+                }
+    put:
+      description: Updates song
+      body:
+        application/json:
+          schema: song
+          example: |
+            {
+              "songId": "2ab846ba-75b6-4b1e-aa3c-937492cd1982",
+              "songTitle": "Insane In The Brain",
+              "artist": "Cypress Hill"
+            }
+      responses:
+        200:
+          description: Successful Response
+          body:
+            application/json:
+              schema: song
+              example: |
+                {
+                  "songId": "2ab846ba-75b6-4b1e-aa3c-937492cd1982",
+                  "songTitle": "Insane In The Brain",
+                  "artist": "Cypress Hill"
+                }
+    delete:
+      description: Deletes song
+      responses:
+        200:
+          description: Successful Response

--- a/springmvc-raml-plugin/README.md
+++ b/springmvc-raml-plugin/README.md
@@ -21,7 +21,7 @@ The SpringMVC-To-RAML plugin  is released under version 2.0 of the [Apache Licen
 
 ## Usage 1 - Generating RAML from Implementation
 
-### Sample Maven Code 
+### Sample Maven Code
 
 The first step is to download and compile these projects using Maven. Simply run mvn clean install in the parent directory and both the plugin and annotations artifacts will be compiled. These can optionally be deployed to your
 Artifactory or similar repo.
@@ -99,7 +99,7 @@ Then simply include the following code in the POM of the project you wish to gen
 
 ## Usage 2 - Style Checking RAML document and Verifying against Implementation
 
-### Sample Maven Code 
+### Sample Maven Code
 
 The first step is to download and compile these projects using Maven. Simply run mvn clean install in the parent directory and both the plugin and annotations artifacts will be compiled. These can optionally be deployed to your
 Artifactory or similar repo.
@@ -129,7 +129,7 @@ Then simply include the following code in the POM of the project you wish to gen
 	<checkForResponseBodySchema>true</checkForResponseBodySchema>
 	<breakBuildOnWarnings>false</breakBuildOnWarnings>
     <logWarnings>true</logWarnings>
-    <logErrors>true</logErrors>	
+    <logErrors>true</logErrors>
 	<ignoredList>
 	   <param>com.package.to.ignore</param>
 	   <param>com.specificClass.to.ignore.ClassName</param>
@@ -166,7 +166,7 @@ Then simply include the following code in the POM of the project you wish to gen
 (optional, default: true) Flag that will enable or disable Style Checking of the RAML file. If this is set to false it will override other style check flags
 
 ### checkForResourceExistence
-(optional, default: true) Flag that will enable or disable Checks for existence of Resources 
+(optional, default: true) Flag that will enable or disable Checks for existence of Resources
 
 ### checkForActionExistence
 (optional, default: true) Flag that will enable or disable Checks for existence of Actions/Verbs
@@ -218,7 +218,7 @@ Then simply include the following code in the POM of the project you wish to gen
 
 ## Usage 3 - Generating SpringMVC Server Endpoints from a RAML file
 
-### Sample Maven Code 
+### Sample Maven Code
 
 The first step is to download and compile these projects using Maven. Simply run mvn clean install in the parent directory and both the plugin and annotations artifacts will be compiled. These can optionally be deployed to your
 Artifactory or similar repo.
@@ -288,7 +288,7 @@ Then simply include the following code in the POM of the project you wish to gen
 (optional, default: false) If set to true, we will generate a `HttpHeaders` parameter for each method to allow using request HTTP headers directly.
 
 ### seperateMethodsByContentType
-(optional, default: false) Should we generate separate API methods for endpoints which define multiple content types in their 200 response. 
+(optional, default: false) Should we generate separate API methods for endpoints which define multiple content types in their 200 response.
 
 ### useJackson1xCompatibility
 (optional, default: false) If set to true, we will generate Jackson 1 annotations inside the model objects.
@@ -297,16 +297,16 @@ Then simply include the following code in the POM of the project you wish to gen
 (optional) This is a key/value map for configuration of individual rules. Not all rules support configuration.
 
 ### rule
-(optional, default: com.phoenixnap.oss.ramlapisync.generation.rules.Spring4ControllerStubRule) The rule class to be used for code generation. 
+(optional, default: com.phoenixnap.oss.ramlapisync.generation.rules.Spring4ControllerStubRule) The rule class to be used for code generation.
 
 #### Available Rules
 - **com.phoenixnap.oss.ramlapisync.generation.rules.Spring3ControllerStubRule**:
-- **com.phoenixnap.oss.ramlapisync.generation.rule.Spring4ControllerStubRule**: 
+- **com.phoenixnap.oss.ramlapisync.generation.rule.Spring4ControllerStubRule**:
 The standard rule. It creates simple controller stubs classes with Spring MVC annotations and empty method bodies (like in v.0.2.4).
 All you have to do is to implement the empty method body for each endpoint. This is simple and easy.
 The drawback: When you regenerate the controller stubs your code will be overriden.
 
-- **com.phoenixnap.oss.ramlapisync.generation.rules.Spring3ControllerDecoratorRule**: 
+- **com.phoenixnap.oss.ramlapisync.generation.rules.Spring3ControllerDecoratorRule**:
 - **com.phoenixnap.oss.ramlapisync.generation.rules.Spring4ControllerDecoratorRule**:
 Creates a controller interface and a decorator with Spring MVC annotations for each top level endpoint.
 The decorator implements the controller interface and delegates all method calls to an @Autowired ControllerDelegate.
@@ -326,6 +326,9 @@ Configuration:
 	restTemplateFieldName: The name of the RestTemplate field
 	restTemplateQualifierBeanName: [OPTIONAL] The name of the bean for the rest template used in the generated client. Default: NONE
 ```
+
+- **com.phoenixnap.oss.ramlapisync.generation.rules.SpringFeignClientInterfaceRule**:
+Creates a standalone `org.springframework.cloud.netflix.feign.FeignClient` (REST client) for each top level endpoint.
 
 ## Contributing
 [Pull requests][] are welcome; Be a good citizen and create unit tests for any bugs squished or features added


### PR DESCRIPTION
Added rule `com.phoenixnap.oss.ramlapisync.generation.rules.SpringFeignClientInterfaceRule` for generating `org.springframework.cloud.netflix.feign.FeignClient` from raml.