### PR TITLE
Use full controller path for class name generation

### DIFF
--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/data/ApiResourceMetadata.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/data/ApiResourceMetadata.java
@@ -66,7 +66,7 @@ public class ApiResourceMetadata {
     
     public String getName() {
     	if(this.resourceDepthInClassNames != 1){
-			return NamingHelper.getAllResourcesNames(resource, singularizeName, this.resourceDepthInClassNames);
+			return NamingHelper.getAllResourcesNames(controllerUrl, singularizeName, this.resourceDepthInClassNames);
 		} else {
 			return NamingHelper.getResourceName(resource, singularizeName);
 		}

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/naming/NamingHelper.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/naming/NamingHelper.java
@@ -307,14 +307,13 @@ public class NamingHelper {
 	/**
 	 * Attempts to infer the name of a resource from a resources's full URL.
 	 * 
-	 * @param ramlResource The raml resource being parsed
+	 * @param url The URL of the raml resource being parsed
 	 * @param singularize Indicates if the resource name should be singularized or not
 	 * @param resourceDepthInClassNames The depth of uri to be included in a name 
 	 * @return
 	 */
-	public static String getAllResourcesNames(RamlResource ramlResource, boolean singularize, int resourceDepthInClassNames) {
-		
-		String url = ramlResource.getUri();
+	public static String getAllResourcesNames(String url, boolean singularize, int resourceDepthInClassNames) {
+
 		StringBuilder stringBuilder = new StringBuilder();
 		if (StringUtils.hasText(url)) {
 			String[] resources = url.split("/");

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/NamingHelperTest.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/NamingHelperTest.java
@@ -58,22 +58,20 @@ public class NamingHelperTest {
 	
 	@Test
 	public void test_getAllResourcesNames_Success() {
-		RamlResource testResource = RamlModelFactoryOfFactories.createRamlModelFactoryV08().createRamlResource();
+
+		String url = "/services/things";
 		
-		testResource.setParentUri("/services");
-		testResource.setRelativeUri("/things");
+		assertEquals("Should deal with unlimited depth", "ServicesThings", NamingHelper.getAllResourcesNames(url, false, -1));
+		assertEquals("Should deal with unlimited depth and singularization", "ServiceThing", NamingHelper.getAllResourcesNames(url, true, -1));
+		assertEquals("Should deal with depth=1", "Things", NamingHelper.getAllResourcesNames(url, false, 1));
+		assertEquals("Should deal with depth=1 and singularization", "Thing", NamingHelper.getAllResourcesNames(url, true, 1));
+		assertEquals("Should deal with depth=2", "ServicesThings", NamingHelper.getAllResourcesNames(url, false, 2));
+		assertEquals("Should deal with depth=2 and singularization", "ServiceThing", NamingHelper.getAllResourcesNames(url, true, 2));
 		
-		assertEquals("Should deal with unlimited depth", "ServicesThings", NamingHelper.getAllResourcesNames(testResource, false, -1));
-		assertEquals("Should deal with unlimited depth and singularization", "ServiceThing", NamingHelper.getAllResourcesNames(testResource, true, -1));
-		assertEquals("Should deal with depth=1", "Things", NamingHelper.getAllResourcesNames(testResource, false, 1));
-		assertEquals("Should deal with depth=1 and singularization", "Thing", NamingHelper.getAllResourcesNames(testResource, true, 1));
-		assertEquals("Should deal with depth=2", "ServicesThings", NamingHelper.getAllResourcesNames(testResource, false, 2));
-		assertEquals("Should deal with depth=2 and singularization", "ServiceThing", NamingHelper.getAllResourcesNames(testResource, true, 2));
+		url = "/services/things/quotes";
 		
-		testResource.setRelativeUri("/things/quotes");
-		
-		assertEquals("Should deal with unlimited depth", "ServicesThingsQuotes", NamingHelper.getAllResourcesNames(testResource, false, -1));
-		assertEquals("Should deal with unlimited depth and singularization", "ServiceThingQuote", NamingHelper.getAllResourcesNames(testResource, true, -1));
+		assertEquals("Should deal with unlimited depth", "ServicesThingsQuotes", NamingHelper.getAllResourcesNames(url, false, -1));
+		assertEquals("Should deal with unlimited depth and singularization", "ServiceThingQuote", NamingHelper.getAllResourcesNames(url, true, -1));
 	}
 
 	@Test

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/SpringMvcResourceParserTest.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/SpringMvcResourceParserTest.java
@@ -226,7 +226,7 @@ public class SpringMvcResourceParserTest {
         controllersMetadataSet = par.extractControllers(new JCodeModel(), published);
 
         controller = controllersMetadataSet.iterator().next();
-        assertEquals("BaseServiceThing", controller.getName());
+        assertEquals("ApiBaseServiceThing", controller.getName());
     }
 
 


### PR DESCRIPTION
This is a proposal to include the full controller path for class name generation when the parameter
`resourceDepthInClassNames` is set.

This is quite useful when there are different versions for the same resource, and that each version has
its own RAML file, with a different `baseUri` for each version.