### PR TITLE
Add support for pattern in Spring MVC controller generation

### DIFF
--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringControllerDecoratorRule.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringControllerDecoratorRule.java
@@ -86,6 +86,7 @@ public abstract class SpringControllerDecoratorRule extends SpringConfigurableRu
                 .setClassCommentRule(new ClassCommentRule())
                 .addClassAnnotationRule(getControllerAnnotationRule())
                 .addClassAnnotationRule(new SpringRequestMappingClassAnnotationRule())
+                .addClassAnnotationRule(new SpringValidatedClassAnnotationRule())
                 .setClassRule(new ControllerClassDeclarationRule("Decorator"))
                 .setImplementsExtendsRule(new ImplementsControllerInterfaceRule(generatedInterface))
                 .addFieldDeclarationRule(new SpringDelegateFieldDeclerationRule(delegateFieldName))

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringControllerStubRule.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringControllerStubRule.java
@@ -61,6 +61,7 @@ public abstract class SpringControllerStubRule extends SpringConfigurableRule {
                 .setClassCommentRule(new ClassCommentRule())
                 .addClassAnnotationRule(getControllerAnnotationRule())
                 .addClassAnnotationRule(new SpringRequestMappingClassAnnotationRule())
+                .addClassAnnotationRule(new SpringValidatedClassAnnotationRule())
                 .setClassRule(new ControllerClassDeclarationRule())
                 .setMethodCommentRule(new MethodCommentRule())
                 .addMethodAnnotationRule(new SpringRequestMappingMethodAnnotationRule())

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringMethodParamsRule.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringMethodParamsRule.java
@@ -13,6 +13,7 @@
 package com.phoenixnap.oss.ramlapisync.generation.rules.spring;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
 
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -82,6 +83,10 @@ public class SpringMethodParamsRule extends MethodParamsRule {
         JAnnotationUse jAnnotationUse;
         if (paramMetaData.getRamlParam() != null && paramMetaData.getRamlParam() instanceof RamlUriParameter) {
             jVar.annotate(PathVariable.class);
+            if (paramMetaData.getRamlParam().getPattern() != null) {
+               jAnnotationUse = jVar.annotate(Pattern.class);
+               jAnnotationUse.param("regexp", paramMetaData.getRamlParam().getPattern());
+            }
             return jVar;
         } else if (paramMetaData.getRamlParam() != null && paramMetaData.getRamlParam() instanceof RamlHeader) {
             jAnnotationUse = jVar.annotate(RequestHeader.class);
@@ -95,6 +100,11 @@ public class SpringMethodParamsRule extends MethodParamsRule {
 				// Supplying a default value implicitly sets required to false.
 				jAnnotationUse.param("required", false);
 			}
+
+			if (paramMetaData.getRamlParam().getPattern() != null) {
+               jAnnotationUse = jVar.annotate(Pattern.class);
+               jAnnotationUse.param("value", paramMetaData.getRamlParam().getPattern());
+         }
 
             return jVar;
         } else {
@@ -115,6 +125,11 @@ public class SpringMethodParamsRule extends MethodParamsRule {
 				// Supplying a default value implicitly sets required to false.
 				jAnnotationUse.param("required", false);
 			}
+
+           if (paramMetaData.getRamlParam().getPattern() != null) {
+              jAnnotationUse = jVar.annotate(Pattern.class);
+              jAnnotationUse.param("regexp", paramMetaData.getRamlParam().getPattern());
+           }
 
             return jVar;
         }

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringValidatedClassAnnotationRule.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringValidatedClassAnnotationRule.java
@@ -1,0 +1,16 @@
+
+package com.phoenixnap.oss.ramlapisync.generation.rules.spring;
+
+import org.springframework.validation.annotation.Validated;
+
+import com.phoenixnap.oss.ramlapisync.data.ApiResourceMetadata;
+import com.phoenixnap.oss.ramlapisync.generation.rules.Rule;
+import com.sun.codemodel.JAnnotationUse;
+import com.sun.codemodel.JDefinedClass;
+
+public class SpringValidatedClassAnnotationRule implements Rule<JDefinedClass, JAnnotationUse, ApiResourceMetadata> {
+   @Override
+   public JAnnotationUse apply(ApiResourceMetadata controllerMetadata, JDefinedClass generatableType) {
+      return generatableType.annotate(Validated.class);
+   }
+}

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/raml/RamlAbstractParam.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/raml/RamlAbstractParam.java
@@ -46,6 +46,8 @@ public abstract class RamlAbstractParam { //extends AbstractParam {
     public abstract String getDisplayName();
 
 	public abstract String getDefaultValue();
+
+	public abstract String getPattern();
 	
 	/**
 	 * Convenience method for easier processing. Non supporting parameters are assumed to be single.

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/raml/rjp/raml08v1/RJP08V1RamlFormParameter.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/raml/rjp/raml08v1/RJP08V1RamlFormParameter.java
@@ -98,6 +98,11 @@ public class RJP08V1RamlFormParameter extends RamlFormParameter {
 	}
 
 	@Override
+   public String getPattern() {
+       return formParameter.getPattern();
+   }
+
+	@Override
 	public void setRepeat(boolean repeat) {
 		formParameter.setRepeat(repeat);
 	}

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/raml/rjp/raml08v1/RJP08V1RamlHeader.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/raml/rjp/raml08v1/RJP08V1RamlHeader.java
@@ -88,6 +88,11 @@ public class RJP08V1RamlHeader extends RamlHeader {
 	public String getDefaultValue() {
 		return header.getDefaultValue();
 	}
+
+	@Override
+   public String getPattern() {
+       return header.getPattern();
+   }
 	
 	@Override
 	public void setType(String type) {

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/raml/rjp/raml08v1/RJP08V1RamlUriParameter.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/raml/rjp/raml08v1/RJP08V1RamlUriParameter.java
@@ -96,6 +96,11 @@ public class RJP08V1RamlUriParameter extends RamlUriParameter {
 	public String getDefaultValue() {
 		return uriParameter.getDefaultValue();
 	}
+
+	@Override
+   public String getPattern() {
+        return uriParameter.getPattern();
+   }
 	
 	@Override
 	public void setType(String type) {

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/raml/rjp/raml10v2/RJP10V2RamlFormParameter.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/raml/rjp/raml10v2/RJP10V2RamlFormParameter.java
@@ -12,6 +12,7 @@
  */
 package com.phoenixnap.oss.ramlapisync.raml.rjp.raml10v2;
 
+import org.raml.v2.api.model.v10.datamodel.StringTypeDeclaration;
 import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
 
 import com.phoenixnap.oss.ramlapisync.data.RamlFormParameter;
@@ -96,6 +97,14 @@ public class RJP10V2RamlFormParameter extends RamlFormParameter {
 	public String getDefaultValue() {
 		return formParameter.defaultValue();
 	}
+
+   @Override
+   public String getPattern() {
+      if (formParameter instanceof StringTypeDeclaration) {
+         return ((StringTypeDeclaration) formParameter).pattern();
+      }
+      return null;
+   }
 
 	@Override
 	public boolean isRepeat() {

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/raml/rjp/raml10v2/RJP10V2RamlHeader.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/raml/rjp/raml10v2/RJP10V2RamlHeader.java
@@ -12,6 +12,7 @@
  */
 package com.phoenixnap.oss.ramlapisync.raml.rjp.raml10v2;
 
+import org.raml.v2.api.model.v10.datamodel.StringTypeDeclaration;
 import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
 
 import com.phoenixnap.oss.ramlapisync.naming.RamlTypeHelper;
@@ -88,6 +89,14 @@ public class RJP10V2RamlHeader extends RamlHeader {
 	public String getDefaultValue() {
 		return header.defaultValue();
 	}
+
+	@Override
+   public String getPattern() {
+      if (header instanceof StringTypeDeclaration) {
+         return ((StringTypeDeclaration) header).pattern();
+      }
+      return null;
+   }
 	
 	@Override
 	public void setType(String type) {

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/raml/rjp/raml10v2/RJP10V2RamlUriParameter.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/raml/rjp/raml10v2/RJP10V2RamlUriParameter.java
@@ -12,6 +12,7 @@
  */
 package com.phoenixnap.oss.ramlapisync.raml.rjp.raml10v2;
 
+import org.raml.v2.api.model.v10.datamodel.StringTypeDeclaration;
 import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
 
 import com.phoenixnap.oss.ramlapisync.naming.RamlTypeHelper;
@@ -96,6 +97,14 @@ public class RJP10V2RamlUriParameter extends RamlUriParameter {
 	public String getDefaultValue() {
 		return this.uriParameter.defaultValue();
 	}
+
+	@Override
+   public String getPattern() {
+       if (uriParameter instanceof StringTypeDeclaration) {
+            return ((StringTypeDeclaration) uriParameter).pattern();
+         }
+         return null;
+   }
 	
 	@Override
 	public void setType(String type) {

--- a/springmvc-raml-parser/src/test/java/com/phoenixnap/oss/ramlapisync/generation/rules/PatternConstraintTest.java
+++ b/springmvc-raml-parser/src/test/java/com/phoenixnap/oss/ramlapisync/generation/rules/PatternConstraintTest.java
@@ -1,0 +1,27 @@
+
+package com.phoenixnap.oss.ramlapisync.generation.rules;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.phoenixnap.oss.ramlapisync.data.ApiResourceMetadata;
+import com.phoenixnap.oss.ramlapisync.raml.InvalidRamlResourceException;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+
+public class PatternConstraintTest extends AbstractRuleTestBase {
+
+   private Rule<JCodeModel, JDefinedClass, ApiResourceMetadata> rule;
+
+   @BeforeClass
+   public static void initRaml() throws InvalidRamlResourceException {
+      AbstractRuleTestBase.RAML = RamlLoader.loadRamlFromFile("test-pattern-constraint.raml");
+   }
+
+   @Test
+   public void applySpring4ControllerDecoratorRule_shouldCreate_validCode() throws Exception {
+      rule = new Spring4ControllerDecoratorRule();
+      rule.apply(getControllerMetadata(), jCodeModel);
+      verifyGeneratedCode("PatternConstraintSpring4Decorator");
+   }
+}

--- a/springmvc-raml-parser/src/test/resources/rules/BaseControllerDecorator.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/BaseControllerDecorator.java.txt
@@ -42,6 +42,7 @@ import java.math.BigDecimal;
 import com.gen.test.model.NamedResponseType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -57,6 +58,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(value = "/api/base", produces = "application/json")
+@Validated
 public class BaseControllerDecorator
     implements BaseController
 {

--- a/springmvc-raml-parser/src/test/resources/rules/BaseControllerDecoratorAsync.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/BaseControllerDecoratorAsync.java.txt
@@ -44,6 +44,7 @@ import java.util.concurrent.Callable;
 import com.gen.test.model.NamedResponseType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -59,6 +60,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(value = "/api/base", produces = "application/json")
+@Validated
 public class BaseControllerDecorator
     implements BaseController
 {

--- a/springmvc-raml-parser/src/test/resources/rules/BaseControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/BaseControllerStub.java.txt
@@ -5,6 +5,7 @@ package com.gen.test;
 import java.math.BigDecimal;
 import com.gen.test.model.NamedResponseType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(value = "/api/base", produces = "application/json")
+@Validated
 public class BaseController {
 
 

--- a/springmvc-raml-parser/src/test/resources/rules/BaseControllerStubAsync.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/BaseControllerStubAsync.java.txt
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.util.concurrent.Callable;
 import com.gen.test.model.NamedResponseType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(value = "/api/base", produces = "application/json")
+@Validated
 public class BaseController {
 
 

--- a/springmvc-raml-parser/src/test/resources/rules/BaseDecoratorRequestBodyWithValidation.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/BaseDecoratorRequestBodyWithValidation.java.txt
@@ -31,6 +31,7 @@ import com.gen.test.model.UpdateBaseRequest;
 import com.gen.test.model.UpdateBaseResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -44,6 +45,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/api/base")
+@Validated
 public class BaseControllerDecorator
     implements BaseController
 {

--- a/springmvc-raml-parser/src/test/resources/rules/BaseHttpHeadersControllerDecorator.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/BaseHttpHeadersControllerDecorator.java.txt
@@ -44,6 +44,7 @@ import com.gen.test.model.NamedResponseType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -59,6 +60,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(value = "/api/base", produces = "application/json")
+@Validated
 public class BaseControllerDecorator
     implements BaseController
 {

--- a/springmvc-raml-parser/src/test/resources/rules/BaseHttpHeadersControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/BaseHttpHeadersControllerStub.java.txt
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import com.gen.test.model.NamedResponseType;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(value = "/api/base", produces = "application/json")
+@Validated
 public class BaseController {
 
 

--- a/springmvc-raml-parser/src/test/resources/rules/BaseStubRequestBodyWithValidation.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/BaseStubRequestBodyWithValidation.java.txt
@@ -5,6 +5,7 @@ package com.gen.test;
 import javax.validation.Valid;
 import com.gen.test.model.UpdateBaseRequest;
 import com.gen.test.model.UpdateBaseResponse;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/api/base")
+@Validated
 public class BaseController {
 
 

--- a/springmvc-raml-parser/src/test/resources/rules/Issue117ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue117ControllerStub.java.txt
@@ -4,6 +4,7 @@ package com.gen.test;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  */
 @Controller
 @RequestMapping(value = "/api/files", produces = "application/json")
+@Validated
 public class FileController {
 
 

--- a/springmvc-raml-parser/src/test/resources/rules/Issue117Spring4ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue117Spring4ControllerStub.java.txt
@@ -3,6 +3,7 @@
 package com.gen.test;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(value = "/api/files", produces = "application/json")
+@Validated
 public class FileController {
 
 

--- a/springmvc-raml-parser/src/test/resources/rules/Issue117Spring4Decorator.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue117Spring4Decorator.java.txt
@@ -26,6 +26,7 @@ package com.gen.test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(value = "/api/files", produces = "application/json")
+@Validated
 public class FileControllerDecorator
     implements FileController
 {

--- a/springmvc-raml-parser/src/test/resources/rules/Issue117Spring4DecoratorNoArray.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue117Spring4DecoratorNoArray.java.txt
@@ -26,6 +26,7 @@ package com.gen.test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(value = "/api/files", produces = "application/json")
+@Validated
 public class FileControllerDecorator
     implements FileController
 {

--- a/springmvc-raml-parser/src/test/resources/rules/MultipartRequestStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/MultipartRequestStub.java.txt
@@ -4,6 +4,7 @@ package com.gen.test;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
  */
 @Controller
 @RequestMapping(value = "/api/base", produces = "application/json")
+@Validated
 public class BaseController {
 
 

--- a/springmvc-raml-parser/src/test/resources/rules/PatternConstraintSpring4Decorator.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/PatternConstraintSpring4Decorator.java.txt
@@ -1,0 +1,72 @@
+-----------------------------------com.gen.test.BaseController.java-----------------------------------
+
+package com.gen.test;
+
+import org.springframework.http.ResponseEntity;
+
+
+/**
+ * No description
+ * (Generated with springmvc-raml-parser v.${project.version})
+ * 
+ */
+public interface BaseController {
+
+
+    /**
+     * No description
+     * 
+     */
+    public ResponseEntity<?> getEndpointById(String id, String param1, String xMyHeader);
+
+}
+-----------------------------------com.gen.test.BaseControllerDecorator.java-----------------------------------
+
+package com.gen.test;
+
+import javax.validation.constraints.Pattern;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * No description
+ * (Generated with springmvc-raml-parser v.${project.version})
+ * 
+ */
+@RestController
+@RequestMapping("/api/base")
+@Validated
+public class BaseControllerDecorator
+    implements BaseController
+{
+
+    @Autowired
+    private BaseController baseControllerDelegate;
+
+    /**
+     * No description
+     * 
+     */
+    @RequestMapping(value = "/endpoint/{id}", method = RequestMethod.GET)
+    public ResponseEntity<?> getEndpointById(
+        @PathVariable
+        @Pattern(regexp = "^.{1,255}$")
+        String id,
+        @RequestParam
+        @Pattern(regexp = "^.{1,255}$")
+        String param1,
+        @RequestHeader(name = "X-My-Header", required = false)
+        @Pattern("^.{1,255}$")
+        String xMyHeader) {
+        return this.baseControllerDelegate.getEndpointById(id, param1, xMyHeader);
+    }
+
+}

--- a/springmvc-raml-parser/src/test/resources/rules/RamlEquivalenceSpring4Decorator.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/RamlEquivalenceSpring4Decorator.java.txt
@@ -35,6 +35,7 @@ import java.util.List;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -48,6 +49,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(value = "/api/persons", produces = "application/json")
+@Validated
 public class PersonControllerDecorator
     implements PersonController
 {

--- a/springmvc-raml-parser/src/test/resources/rules/Spring3BaseControllerDecorator.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Spring3BaseControllerDecorator.java.txt
@@ -43,6 +43,7 @@ import com.gen.test.model.NamedResponseType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -58,6 +59,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  */
 @Controller
 @RequestMapping(value = "/api/base", produces = "application/json")
+@Validated
 public class BaseControllerDecorator
     implements BaseController
 {

--- a/springmvc-raml-parser/src/test/resources/rules/Spring3BaseControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Spring3BaseControllerStub.java.txt
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import com.gen.test.model.NamedResponseType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  */
 @Controller
 @RequestMapping(value = "/api/base", produces = "application/json")
+@Validated
 public class BaseController {
 
 

--- a/springmvc-raml-parser/src/test/resources/rules/Spring3HttpHeadersBaseControllerDecorator.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Spring3HttpHeadersBaseControllerDecorator.java.txt
@@ -45,6 +45,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -60,6 +61,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  */
 @Controller
 @RequestMapping(value = "/api/base", produces = "application/json")
+@Validated
 public class BaseControllerDecorator
     implements BaseController
 {

--- a/springmvc-raml-parser/src/test/resources/rules/Spring3HttpHeadersBaseControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Spring3HttpHeadersBaseControllerStub.java.txt
@@ -7,6 +7,7 @@ import com.gen.test.model.NamedResponseType;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  */
 @Controller
 @RequestMapping(value = "/api/base", produces = "application/json")
+@Validated
 public class BaseController {
 
 

--- a/springmvc-raml-parser/src/test/resources/test-pattern-constraint.raml
+++ b/springmvc-raml-parser/src/test/resources/test-pattern-constraint.raml
@@ -1,0 +1,19 @@
+#%RAML 0.8
+title: myapi
+baseUri: /
+version: 1
+
+/base:
+  /endpoint/{id}:
+    uriParameters:
+      id:
+        pattern: ^.{1,255}$
+    get:
+      queryParameters:
+        param1:
+          required: true
+          pattern: ^.{1,255}$
+      headers:
+        X-My-Header:
+          type: string
+          pattern: ^.{1,255}$


### PR DESCRIPTION
This add `@Validated` annotation to controllers (stub and decorator) so that Spring
validation is activated (and not only JSR-303 validation) and allows to check for patterns.

Fix #108 