### PR TITLE
Fix use of @Pattern

### DIFF
--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringMethodParamsRule.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/rules/spring/SpringMethodParamsRule.java
@@ -103,7 +103,7 @@ public class SpringMethodParamsRule extends MethodParamsRule {
 
 			if (paramMetaData.getRamlParam().getPattern() != null) {
                jAnnotationUse = jVar.annotate(Pattern.class);
-               jAnnotationUse.param("value", paramMetaData.getRamlParam().getPattern());
+               jAnnotationUse.param("regexp", paramMetaData.getRamlParam().getPattern());
          }
 
             return jVar;

--- a/springmvc-raml-parser/src/test/resources/rules/PatternConstraintSpring4Decorator.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/PatternConstraintSpring4Decorator.java.txt
@@ -64,7 +64,7 @@ public class BaseControllerDecorator
         @Pattern(regexp = "^.{1,255}$")
         String param1,
         @RequestHeader(name = "X-My-Header", required = false)
-        @Pattern("^.{1,255}$")
+        @Pattern(regexp = "^.{1,255}$")
         String xMyHeader) {
         return this.baseControllerDelegate.getEndpointById(id, param1, xMyHeader);
     }


### PR DESCRIPTION
The last release introduced the validation of the decorator using the annotation @Pattern. In some cases, this can leads to compilation errors because the annotation does not have any 'value' attribute. The 'regexp' must be used instead.

```
/XXXXXXXXXXXXXXXXXXXXXX.java:[44,18] cannot find symbol
  symbol:   method value()
  location: @interface javax.validation.constraints.Pattern
```