### PR TITLE
Add support for Union types

### DIFF
--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/pojo/RamlInterpreterFactory.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/pojo/RamlInterpreterFactory.java
@@ -33,7 +33,8 @@ public class RamlInterpreterFactory {
 	static RamlTypeInterpreter DEFAULT_INTERPRETER = new StringTypeInterpreter();
 	static RamlTypeInterpreter[] SUPPORTED_INTERPRETERS = { new ObjectTypeInterpreter(), new BooleanTypeInterpreter(),
 			new NullTypeInterpreter(), new NumberTypeInterpreter(), new ArrayTypeInterpreter(),
-			new AnyTypeInterpreter(), new FileTypeInterpreter(), new DateTypeInterpreter(), DEFAULT_INTERPRETER };
+			new AnyTypeInterpreter(), new FileTypeInterpreter(), new DateTypeInterpreter(), new UnionTypeInterpreter(),
+			DEFAULT_INTERPRETER };
 
 	private static Map<Class<? extends TypeDeclaration>, RamlTypeInterpreter> interpreters = new LinkedHashMap<>();
 	private static Map<Class<? extends TypeDeclaration>, RamlTypeInterpreter> interpreterCache = new LinkedHashMap<>();

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/pojo/UnionTypeInterpreter.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/pojo/UnionTypeInterpreter.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.phoenixnap.oss.ramlapisync.pojo;
+
+import com.phoenixnap.oss.ramlapisync.naming.RamlTypeHelper;
+import com.phoenixnap.oss.ramlapisync.raml.RamlDataType;
+import com.phoenixnap.oss.ramlapisync.raml.RamlRoot;
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JCodeModel;
+import org.raml.v2.api.model.v10.datamodel.ObjectTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.UnionTypeDeclaration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.MimeType;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Interpreter for Union types.
+ *
+ * @author rahul
+ * @since 0.10.6
+ */
+public class UnionTypeInterpreter extends BaseTypeInterpreter {
+
+    protected static final Logger logger = LoggerFactory.getLogger(UnionTypeInterpreter.class);
+
+    @Override
+    public Set<Class<? extends TypeDeclaration>> getSupportedTypes() {
+        return Collections.singleton(UnionTypeDeclaration.class);
+    }
+
+    private String getClassName(TypeDeclaration type) {
+        UnionTypeDeclaration objectType = (UnionTypeDeclaration) type;
+        String name = StringUtils.capitalize(objectType.name());
+
+        // For mime types we need to take the type not the name
+        try {
+            MimeType.valueOf(name);
+            name = objectType.type();
+        } catch (Exception ex) {
+            // not a valid mimetype do nothing
+            logger.debug("mime: " + name);
+        }
+        return name;
+    }
+
+    private TypeDeclaration getParent(UnionTypeDeclaration objectType, String typeName, RamlRoot document) {
+        Map<String, RamlDataType> types = document.getTypes();
+
+        TypeDeclaration parent = null;
+
+        if (!RamlTypeHelper.isBaseObject(typeName)) {
+            parent = types.get(typeName).getType();
+        } else if (objectType.parentTypes() != null && objectType.parentTypes().size() > 0) {
+            TypeDeclaration tempParent = objectType.parentTypes().get(0); // java doesnt support multiple parents take first;
+            if (!RamlTypeHelper.isBaseObject(tempParent.name())) {
+                parent = types.get(tempParent.name()).getType();
+            }
+        } else {
+            parent = null;
+        }
+        return parent;
+    }
+
+    @Override
+    public RamlInterpretationResult interpret(RamlRoot document, TypeDeclaration type, JCodeModel builderModel,
+                                              PojoGenerationConfig config, boolean property) {
+        RamlInterpretationResult result = new RamlInterpretationResult(type.required());
+        typeCheck(type);
+
+        String name = getClassName(type);
+
+        UnionTypeDeclaration objectType = (UnionTypeDeclaration) type;
+        String typeName = objectType.type();
+
+        // Lets check if we've already handled this class before.
+        if (builderModel != null) {
+            JClass searchedClass = builderModel._getClass(config.getPojoPackage() + "." + name);
+            if (searchedClass != null) {
+                // we've already handled this pojo in the model, no need to re-interpret
+                result.setCodeModel(builderModel);
+                result.setResolvedClass(searchedClass);
+                return result;
+            }
+        } else {
+            builderModel = new JCodeModel();
+            result.setCodeModel(builderModel);
+        }
+
+        PojoBuilder builder = new PojoBuilder(config, builderModel, name);
+        result.setBuilder(builder);
+
+        TypeDeclaration parent = getParent(objectType, typeName, document);
+
+        if (parent != null && !(parent.name().equals(name))) { //add cyclic dependency check
+            RamlInterpretationResult childResult = RamlInterpreterFactory
+                    .getInterpreterForType(parent)
+                    .interpret(document, parent, builderModel, config, false);
+            String childType = childResult.getResolvedClassOrBuiltOrObject().name();
+
+            builder.extendsClass(childType);
+        }
+
+        for (TypeDeclaration objectProperty : objectType.of()) {
+            RamlInterpretationResult childResult =
+                    RamlInterpreterFactory
+                            .getInterpreterForType(objectProperty).interpret(
+                            document, objectProperty, builderModel, config, true);
+
+            String childType = childResult.getResolvedClassOrBuiltOrObject().fullName();
+            builder.withField(objectProperty.name(), childType,
+                    RamlTypeHelper.getDescription(objectProperty),
+                    childResult.getValidations(), objectProperty.defaultValue());
+        }
+        // Add a constructor with all fields
+        builder.withCompleteConstructor();
+
+        return result;
+
+    }
+
+}

--- a/springmvc-raml-parser/src/test/java/com/phoenixnap/oss/ramlapisync/pojo/UnionTypeInterpretorTest.java
+++ b/springmvc-raml-parser/src/test/java/com/phoenixnap/oss/ramlapisync/pojo/UnionTypeInterpretorTest.java
@@ -1,0 +1,42 @@
+package com.phoenixnap.oss.ramlapisync.pojo;
+
+import com.phoenixnap.oss.ramlapisync.data.ApiResourceMetadata;
+import com.phoenixnap.oss.ramlapisync.generation.RamlParser;
+import com.phoenixnap.oss.ramlapisync.generation.rules.AbstractRuleTestBase;
+import com.phoenixnap.oss.ramlapisync.generation.rules.RamlLoader;
+import com.phoenixnap.oss.ramlapisync.generation.rules.Rule;
+import com.phoenixnap.oss.ramlapisync.generation.rules.Spring4ControllerInterfaceRule;
+import com.phoenixnap.oss.ramlapisync.raml.InvalidRamlResourceException;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author rahul
+ * @since 0.10.6
+ */
+public class UnionTypeInterpretorTest extends AbstractRuleTestBase {
+
+	private Rule<JCodeModel, JDefinedClass, ApiResourceMetadata> rule;
+
+	public UnionTypeInterpretorTest() {
+		super();
+		defaultRamlParser = new RamlParser(new PojoGenerationConfig().withPackage("com.gen.test", null), "/api", false,
+				false, 2);
+	}
+
+	@BeforeClass
+	public static void initRaml() throws InvalidRamlResourceException {
+		AbstractRuleTestBase.RAML = RamlLoader.loadRamlFromFile(AbstractRuleTestBase.RESOURCE_BASE + "raml-with-union-types.raml");
+	}
+
+	@Test
+	public void applySpring4ClientStubRule_shouldCreate_validCode() throws Exception {
+
+		rule = new Spring4ControllerInterfaceRule();
+		rule.apply(getControllerMetadata(), jCodeModel);
+		String removedSerialVersionUID = removeSerialVersionUID(serializeModel());
+		verifyGeneratedCode("RamlWithUnionTypeSpring4ControllerInterface", removedSerialVersionUID);
+	}
+}

--- a/springmvc-raml-parser/src/test/resources/rules/RamlWithUnionTypeSpring4ControllerInterface.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/RamlWithUnionTypeSpring4ControllerInterface.java.txt
@@ -1,0 +1,310 @@
+-----------------------------------com.gen.test.model.Device.java-----------------------------------
+
+package com.gen.test.model;
+
+import java.io.Serializable;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+public class Device implements Serializable
+{
+
+    private com.gen.test.model.Phone Phone;
+    private com.gen.test.model.Notebook Notebook;
+
+    /**
+     * Creates a new Device.
+     *
+     */
+    public Device() {
+        super();
+    }
+
+    /**
+     * Creates a new Device.
+     *
+     */
+    public Device(com.gen.test.model.Phone Phone, com.gen.test.model.Notebook Notebook) {
+        super();
+        this.Phone = Phone;
+        this.Notebook = Notebook;
+    }
+
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Device) == false) {
+            return false;
+        }
+        Device otherObject = ((Device) other);
+        return new EqualsBuilder().isEquals();
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder().toHashCode();
+    }
+
+    /**
+     * Returns the Phone.
+     *
+     * @return
+     *     Phone
+     */
+    public com.gen.test.model.Phone getPhone() {
+        return Phone;
+    }
+
+    /**
+     * Set the Phone.
+     *
+     * @param Phone
+     *     the new Phone
+     */
+    public void setPhone(com.gen.test.model.Phone Phone) {
+        this.Phone = Phone;
+    }
+
+    /**
+     * Returns the Notebook.
+     *
+     * @return
+     *     Notebook
+     */
+    public com.gen.test.model.Notebook getNotebook() {
+        return Notebook;
+    }
+
+    /**
+     * Set the Notebook.
+     *
+     * @param Notebook
+     *     the new Notebook
+     */
+    public void setNotebook(com.gen.test.model.Notebook Notebook) {
+        this.Notebook = Notebook;
+    }
+
+}
+-----------------------------------com.gen.test.model.Notebook.java-----------------------------------
+
+package com.gen.test.model;
+
+import java.io.Serializable;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+public class Notebook implements Serializable
+{
+
+    private String manufacturer;
+    private Double numberOfUSBPorts;
+
+    /**
+     * Creates a new Notebook.
+     *
+     */
+    public Notebook() {
+        super();
+    }
+
+    /**
+     * Creates a new Notebook.
+     *
+     */
+    public Notebook(String manufacturer, Double numberOfUSBPorts) {
+        super();
+        this.manufacturer = manufacturer;
+        this.numberOfUSBPorts = numberOfUSBPorts;
+    }
+
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Notebook) == false) {
+            return false;
+        }
+        Notebook otherObject = ((Notebook) other);
+        return new EqualsBuilder().isEquals();
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder().toHashCode();
+    }
+
+    /**
+     * Returns the manufacturer.
+     *
+     * @return
+     *     manufacturer
+     */
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    /**
+     * Set the manufacturer.
+     *
+     * @param manufacturer
+     *     the new manufacturer
+     */
+    public void setManufacturer(String manufacturer) {
+        this.manufacturer = manufacturer;
+    }
+
+    /**
+     * Returns the numberOfUSBPorts.
+     *
+     * @return
+     *     numberOfUSBPorts
+     */
+    public Double getNumberOfUSBPorts() {
+        return numberOfUSBPorts;
+    }
+
+    /**
+     * Set the numberOfUSBPorts.
+     *
+     * @param numberOfUSBPorts
+     *     the new numberOfUSBPorts
+     */
+    public void setNumberOfUSBPorts(Double numberOfUSBPorts) {
+        this.numberOfUSBPorts = numberOfUSBPorts;
+    }
+
+}
+-----------------------------------com.gen.test.model.Phone.java-----------------------------------
+
+package com.gen.test.model;
+
+import java.io.Serializable;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+public class Phone implements Serializable
+{
+    private String manufacturer;
+    private Double numberOfSIMCards;
+
+    /**
+     * Creates a new Phone.
+     *
+     */
+    public Phone() {
+        super();
+    }
+
+    /**
+     * Creates a new Phone.
+     *
+     */
+    public Phone(String manufacturer, Double numberOfSIMCards) {
+        super();
+        this.manufacturer = manufacturer;
+        this.numberOfSIMCards = numberOfSIMCards;
+    }
+
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Phone) == false) {
+            return false;
+        }
+        Phone otherObject = ((Phone) other);
+        return new EqualsBuilder().isEquals();
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder().toHashCode();
+    }
+
+    /**
+     * Returns the manufacturer.
+     *
+     * @return
+     *     manufacturer
+     */
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    /**
+     * Set the manufacturer.
+     *
+     * @param manufacturer
+     *     the new manufacturer
+     */
+    public void setManufacturer(String manufacturer) {
+        this.manufacturer = manufacturer;
+    }
+
+    /**
+     * Returns the numberOfSIMCards.
+     *
+     * @return
+     *     numberOfSIMCards
+     */
+    public Double getNumberOfSIMCards() {
+        return numberOfSIMCards;
+    }
+
+    /**
+     * Set the numberOfSIMCards.
+     *
+     * @param numberOfSIMCards
+     *     the new numberOfSIMCards
+     */
+    public void setNumberOfSIMCards(Double numberOfSIMCards) {
+        this.numberOfSIMCards = numberOfSIMCards;
+    }
+
+}
+-----------------------------------com.gen.test.ApiDeviceController.java-----------------------------------
+
+package com.gen.test;
+
+import com.gen.test.model.Device;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * Api for devices
+ * (Generated with springmvc-raml-parser v.${project.version})
+ *
+ */
+@RestController
+@RequestMapping(value = "/api/devices", produces = "application/json")
+public interface ApiDeviceController {
+
+
+    /**
+     * No description
+     *
+     */
+    @RequestMapping(value = "/{id}", method = RequestMethod.GET)
+    public ResponseEntity<Device> getDeviceById(
+        @PathVariable
+        String id);
+
+}

--- a/springmvc-raml-parser/src/test/resources/rules/raml-with-union-types.raml
+++ b/springmvc-raml-parser/src/test/resources/rules/raml-with-union-types.raml
@@ -1,0 +1,31 @@
+#%RAML 1.0
+title: My API With Types
+mediaType: application/json
+baseUri: /api
+
+types:
+  Phone:
+    type: object
+    properties:
+      manufacturer:
+        type: string
+      numberOfSIMCards:
+        type: number
+  Notebook:
+    type: object
+    properties:
+      manufacturer:
+        type: string
+      numberOfUSBPorts:
+        type: number
+  Device:
+    type: Phone | Notebook
+
+/devices:
+  description: "Api for devices"
+  /{id}:
+    get:
+      responses:
+        200:
+          body:
+            type: Device


### PR DESCRIPTION
Thanks for creating and maintaining such a useful project. I have recently started using Raml and found your project to be very useful. 

While using the plugin, I realized that currently union types are not supported for code generation. I went through the code and realized that the adding support for the same wont be much effort. Hence I have worked this and I am submitting a PR.

I have kept most of the code consistent with the conventions followed, however, I request you to please review the changes and comment for any changes/suggestions.

For adding support for union types, code is similar to what `ObjectTypeInterpreter` does, but I have not abstracted the behaviour as I did not want to change the object interpreter for any undesired changes as this is my first PR and I may not have understood the codebase too well.