### PR TITLE
[GH-178] Updated generation for equals() and hashCode() methods

### DIFF
--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/pojo/ObjectTypeInterpreter.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/pojo/ObjectTypeInterpreter.java
@@ -128,6 +128,9 @@ public class ObjectTypeInterpreter extends BaseTypeInterpreter {
 		// Add a constructor with all fields
 		builder.withCompleteConstructor();
 
+		// Add overriden hashCode(), equals() and toString() methods
+		builder.withOverridenMethods();
+
 		return result;
 	}
 

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/pojo/PojoBuilder.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/pojo/PojoBuilder.java
@@ -35,7 +35,9 @@ import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JExpr;
 import com.sun.codemodel.JExpression;
+import com.sun.codemodel.JExpressionImpl;
 import com.sun.codemodel.JFieldVar;
+import com.sun.codemodel.JFormatter;
 import com.sun.codemodel.JInvocation;
 import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
@@ -355,7 +357,7 @@ public class PojoBuilder extends AbstractBuilder {
     private void withHashCode() {
         JMethod hashCode = this.pojo.method(JMod.PUBLIC, int.class, "hashCode");
 
-        Class<?> hashCodeBuilder = HashCodeBuilder.class;
+        Class<?> hashCodeBuilder = org.apache.commons.lang3.builder.HashCodeBuilder.class;
         if (!config.isUseCommonsLang3()) {
         	hashCodeBuilder = org.apache.commons.lang.builder.HashCodeBuilder.class;
         }
@@ -366,12 +368,11 @@ public class PojoBuilder extends AbstractBuilder {
             hashCodeBuilderInvocation = hashCodeBuilderInvocation.invoke("appendSuper")
                     .arg(JExpr._super().invoke("hashCode"));
         }
-        
-        hashCode.body()._return(hashCodeBuilderInvocation.invoke("toHashCode"));
+
+        hashCode.body()._return(this.pojo.owner().ref(hashCodeBuilder).staticInvoke("reflectionHashCode").arg(JExpr._this()).arg(JExpr.lit(Boolean.FALSE)));
     }
 
     private void withEquals() {
-       
         JMethod equals = this.pojo.method(JMod.PUBLIC, boolean.class, "equals");
         JVar otherObject = equals.param(Object.class, "other");
 
@@ -384,19 +385,10 @@ public class PojoBuilder extends AbstractBuilder {
 
         body._if(otherObject.eq(JExpr._this()))._then()._return(JExpr.TRUE);
         body._if(otherObject._instanceof(this.pojo).eq(JExpr.FALSE))._then()._return(JExpr.FALSE);
-        
+
         otherObjectVar = body.decl(this.pojo, "otherObject").init(JExpr.cast(this.pojo, otherObject));
-        equalsBuilderInvocation = JExpr._new( this.pojo.owner().ref(equalsBuilder));
 
-        if (!this.pojo._extends().name().equals("Object")) {
-            equalsBuilderInvocation = equalsBuilderInvocation.invoke("appendSuper").arg(JExpr.TRUE);
-        }
-        
-        this.pojo.owner()
-        	.ref(equalsBuilder)
-        	.staticInvoke("reflectionEquals").arg(JExpr._this()).arg(otherObject);
-
-        body._return(equalsBuilderInvocation.invoke("isEquals"));
+        body._return(this.pojo.owner().ref(equalsBuilder).staticInvoke("reflectionEquals").arg(JExpr._this()).arg(otherObjectVar).arg(JExpr.lit(Boolean.FALSE)));
     }
 
 }

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/pojo/UnionTypeInterpreter.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/pojo/UnionTypeInterpreter.java
@@ -17,7 +17,6 @@ import com.phoenixnap.oss.ramlapisync.raml.RamlDataType;
 import com.phoenixnap.oss.ramlapisync.raml.RamlRoot;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JCodeModel;
-import org.raml.v2.api.model.v10.datamodel.ObjectTypeDeclaration;
 import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
 import org.raml.v2.api.model.v10.datamodel.UnionTypeDeclaration;
 import org.slf4j.Logger;
@@ -129,6 +128,9 @@ public class UnionTypeInterpreter extends BaseTypeInterpreter {
         }
         // Add a constructor with all fields
         builder.withCompleteConstructor();
+
+		// Add overriden hashCode(), equals() and toString() methods
+		builder.withOverridenMethods();
 
         return result;
 

--- a/springmvc-raml-parser/src/test/java/com/phoenixnap/oss/ramlapisync/generation/rules/RamlSchemaWithInheritanceTest.java
+++ b/springmvc-raml-parser/src/test/java/com/phoenixnap/oss/ramlapisync/generation/rules/RamlSchemaWithInheritanceTest.java
@@ -1,0 +1,31 @@
+package com.phoenixnap.oss.ramlapisync.generation.rules;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.phoenixnap.oss.ramlapisync.data.ApiResourceMetadata;
+import com.phoenixnap.oss.ramlapisync.raml.InvalidRamlResourceException;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+
+/**
+ * @author slavisam
+ * @since 0.10.9
+ */
+public class RamlSchemaWithInheritanceTest extends AbstractRuleTestBase {
+
+	private Rule<JCodeModel, JDefinedClass, ApiResourceMetadata> rule;
+
+	@BeforeClass
+	public static void initRaml() throws InvalidRamlResourceException {
+		AbstractRuleTestBase.RAML = RamlLoader.loadRamlFromFile(AbstractRuleTestBase.RESOURCE_BASE + "SchemaWithInheritance.raml");
+	}
+
+	@Test
+	public void applySpring4ControllerStubRule_shouldCreate_validCode() throws Exception {
+		rule = new Spring4ControllerStubRule();
+		rule.apply(getControllerMetadata(), jCodeModel);
+		String removedSerialVersionUID = removeSerialVersionUID(serializeModel());
+		verifyGeneratedCode("RamlSchemaWithInheritanceTest", removedSerialVersionUID);
+	}
+}

--- a/springmvc-raml-parser/src/test/resources/rules/Issue158Spring4ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue158Spring4ControllerStub.java.txt
@@ -82,7 +82,7 @@ public class User implements Serializable
         if (other == this) {
             return true;
         }
-        if ((other instanceof User) == false) {
+        if (this.getClass()!= other.getClass()) {
             return false;
         }
         User otherObject = ((User) other);
@@ -90,7 +90,7 @@ public class User implements Serializable
     }
 
     public String toString() {
-        return new ToStringBuilder().append("firstName", firstName).append("lastName", lastName).toString();
+        return new ToStringBuilder(this).append("firstName", firstName).append("lastName", lastName).toString();
     }
 
 }

--- a/springmvc-raml-parser/src/test/resources/rules/Issue158Spring4ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue158Spring4ControllerStub.java.txt
@@ -43,11 +43,11 @@ public class User implements Serializable
             return false;
         }
         User otherObject = ((User) other);
-        return EqualsBuilder.reflectionEquals(this, otherObject, false);
+        return new EqualsBuilder().isEquals();
     }
 
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this, false);
+        return new HashCodeBuilder().toHashCode();
     }
 
     /**

--- a/springmvc-raml-parser/src/test/resources/rules/Issue158Spring4ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue158Spring4ControllerStub.java.txt
@@ -43,11 +43,11 @@ public class User implements Serializable
             return false;
         }
         User otherObject = ((User) other);
-        return new EqualsBuilder().isEquals();
+        return EqualsBuilder.reflectionEquals(this, otherObject, false);
     }
 
     public int hashCode() {
-        return new HashCodeBuilder().toHashCode();
+        return HashCodeBuilder.reflectionHashCode(this, false);
     }
 
     /**

--- a/springmvc-raml-parser/src/test/resources/rules/Issue158Spring4ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue158Spring4ControllerStub.java.txt
@@ -31,25 +31,6 @@ public class User implements Serializable
         this.lastName = lastName;
     }
 
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
-    }
-
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-        if ((other instanceof User) == false) {
-            return false;
-        }
-        User otherObject = ((User) other);
-        return new EqualsBuilder().isEquals();
-    }
-
-    public int hashCode() {
-        return new HashCodeBuilder().toHashCode();
-    }
-
     /**
      * Returns the firstName.
      * 
@@ -88,6 +69,28 @@ public class User implements Serializable
      */
     public void setLastName(String lastName) {
         this.lastName = lastName;
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder().append(firstName).append(lastName).toHashCode();
+    }
+
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof User) == false) {
+            return false;
+        }
+        User otherObject = ((User) other);
+        return new EqualsBuilder().append(firstName, otherObject.firstName).append(lastName, otherObject.lastName).isEquals();
+    }
+
+    public String toString() {
+        return new ToStringBuilder().append("firstName", firstName).append("lastName", lastName).toString();
     }
 
 }

--- a/springmvc-raml-parser/src/test/resources/rules/Issue159Spring4ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue159Spring4ControllerStub.java.txt
@@ -45,11 +45,11 @@ public class Manager implements Serializable
             return false;
         }
         Manager otherObject = ((Manager) other);
-        return EqualsBuilder.reflectionEquals(this, otherObject, false);
+        return new EqualsBuilder().isEquals();
     }
 
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this, false);
+        return new HashCodeBuilder().toHashCode();
     }
 
     /**

--- a/springmvc-raml-parser/src/test/resources/rules/Issue159Spring4ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue159Spring4ControllerStub.java.txt
@@ -33,25 +33,6 @@ public class Manager implements Serializable
         this.departman = departman;
     }
 
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
-    }
-
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-        if ((other instanceof Manager) == false) {
-            return false;
-        }
-        Manager otherObject = ((Manager) other);
-        return new EqualsBuilder().isEquals();
-    }
-
-    public int hashCode() {
-        return new HashCodeBuilder().toHashCode();
-    }
-
     /**
      * Returns the firstName.
      * 
@@ -110,6 +91,28 @@ public class Manager implements Serializable
      */
     public void setDepartman(String departman) {
         this.departman = departman;
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder().append(firstName).append(lastName).append(departman).toHashCode();
+    }
+
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Manager) == false) {
+            return false;
+        }
+        Manager otherObject = ((Manager) other);
+        return new EqualsBuilder().append(firstName, otherObject.firstName).append(lastName, otherObject.lastName).append(departman, otherObject.departman).isEquals();
+    }
+
+    public String toString() {
+        return new ToStringBuilder().append("firstName", firstName).append("lastName", lastName).append("departman", departman).toString();
     }
 
 }

--- a/springmvc-raml-parser/src/test/resources/rules/Issue159Spring4ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue159Spring4ControllerStub.java.txt
@@ -104,7 +104,7 @@ public class Manager implements Serializable
         if (other == this) {
             return true;
         }
-        if ((other instanceof Manager) == false) {
+        if (this.getClass()!= other.getClass()) {
             return false;
         }
         Manager otherObject = ((Manager) other);
@@ -112,7 +112,7 @@ public class Manager implements Serializable
     }
 
     public String toString() {
-        return new ToStringBuilder().append("firstName", firstName).append("lastName", lastName).append("departman", departman).toString();
+        return new ToStringBuilder(this).append("firstName", firstName).append("lastName", lastName).append("departman", departman).toString();
     }
 
 }

--- a/springmvc-raml-parser/src/test/resources/rules/Issue159Spring4ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue159Spring4ControllerStub.java.txt
@@ -45,11 +45,11 @@ public class Manager implements Serializable
             return false;
         }
         Manager otherObject = ((Manager) other);
-        return new EqualsBuilder().isEquals();
+        return EqualsBuilder.reflectionEquals(this, otherObject, false);
     }
 
     public int hashCode() {
-        return new HashCodeBuilder().toHashCode();
+        return HashCodeBuilder.reflectionHashCode(this, false);
     }
 
     /**

--- a/springmvc-raml-parser/src/test/resources/rules/Issue172Spring4ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue172Spring4ControllerStub.java.txt
@@ -39,25 +39,6 @@ public class EventCreate implements Serializable
         this.eventPayload = eventPayload;
     }
 
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
-    }
-
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-        if ((other instanceof EventCreate) == false) {
-            return false;
-        }
-        EventCreate otherObject = ((EventCreate) other);
-        return new EqualsBuilder().isEquals();
-    }
-
-    public int hashCode() {
-        return new HashCodeBuilder().toHashCode();
-    }
-
     /**
      * Returns the eventName.
      * 
@@ -98,6 +79,28 @@ public class EventCreate implements Serializable
         this.eventPayload = eventPayload;
     }
 
+    public int hashCode() {
+        return new HashCodeBuilder().append(eventName).append(eventPayload).toHashCode();
+    }
+
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof EventCreate) == false) {
+            return false;
+        }
+        EventCreate otherObject = ((EventCreate) other);
+        return new EqualsBuilder().append(eventName, otherObject.eventName).append(eventPayload, otherObject.eventPayload).isEquals();
+    }
+
+    public String toString() {
+        return new ToStringBuilder().append("eventName", eventName).append("eventPayload", eventPayload).toString();
+    }
+
 }
 -----------------------------------com.gen.test.model.EventPayload.java-----------------------------------
 
@@ -120,11 +123,14 @@ public class EventPayload implements Serializable
         super();
     }
 
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
+    public int hashCode() {
+        return new HashCodeBuilder().toHashCode();
     }
 
     public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
         if (other == this) {
             return true;
         }
@@ -135,8 +141,8 @@ public class EventPayload implements Serializable
         return new EqualsBuilder().isEquals();
     }
 
-    public int hashCode() {
-        return new HashCodeBuilder().toHashCode();
+    public String toString() {
+        return new ToStringBuilder().toString();
     }
 
 }

--- a/springmvc-raml-parser/src/test/resources/rules/Issue172Spring4ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue172Spring4ControllerStub.java.txt
@@ -51,11 +51,11 @@ public class EventCreate implements Serializable
             return false;
         }
         EventCreate otherObject = ((EventCreate) other);
-        return new EqualsBuilder().isEquals();
+        return EqualsBuilder.reflectionEquals(this, otherObject, false);
     }
 
     public int hashCode() {
-        return new HashCodeBuilder().toHashCode();
+        return HashCodeBuilder.reflectionHashCode(this, false);
     }
 
     /**
@@ -132,11 +132,11 @@ public class EventPayload implements Serializable
             return false;
         }
         EventPayload otherObject = ((EventPayload) other);
-        return new EqualsBuilder().isEquals();
+        return EqualsBuilder.reflectionEquals(this, otherObject, false);
     }
 
     public int hashCode() {
-        return new HashCodeBuilder().toHashCode();
+        return HashCodeBuilder.reflectionHashCode(this, false);
     }
 
 }

--- a/springmvc-raml-parser/src/test/resources/rules/Issue172Spring4ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue172Spring4ControllerStub.java.txt
@@ -90,7 +90,7 @@ public class EventCreate implements Serializable
         if (other == this) {
             return true;
         }
-        if ((other instanceof EventCreate) == false) {
+        if (this.getClass()!= other.getClass()) {
             return false;
         }
         EventCreate otherObject = ((EventCreate) other);
@@ -98,7 +98,7 @@ public class EventCreate implements Serializable
     }
 
     public String toString() {
-        return new ToStringBuilder().append("eventName", eventName).append("eventPayload", eventPayload).toString();
+        return new ToStringBuilder(this).append("eventName", eventName).append("eventPayload", eventPayload).toString();
     }
 
 }
@@ -134,7 +134,7 @@ public class EventPayload implements Serializable
         if (other == this) {
             return true;
         }
-        if ((other instanceof EventPayload) == false) {
+        if (this.getClass()!= other.getClass()) {
             return false;
         }
         EventPayload otherObject = ((EventPayload) other);
@@ -142,7 +142,7 @@ public class EventPayload implements Serializable
     }
 
     public String toString() {
-        return new ToStringBuilder().toString();
+        return new ToStringBuilder(this).toString();
     }
 
 }

--- a/springmvc-raml-parser/src/test/resources/rules/Issue172Spring4ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue172Spring4ControllerStub.java.txt
@@ -51,11 +51,11 @@ public class EventCreate implements Serializable
             return false;
         }
         EventCreate otherObject = ((EventCreate) other);
-        return EqualsBuilder.reflectionEquals(this, otherObject, false);
+        return new EqualsBuilder().isEquals();
     }
 
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this, false);
+        return new HashCodeBuilder().toHashCode();
     }
 
     /**
@@ -132,11 +132,11 @@ public class EventPayload implements Serializable
             return false;
         }
         EventPayload otherObject = ((EventPayload) other);
-        return EqualsBuilder.reflectionEquals(this, otherObject, false);
+        return new EqualsBuilder().isEquals();
     }
 
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this, false);
+        return new HashCodeBuilder().toHashCode();
     }
 
 }

--- a/springmvc-raml-parser/src/test/resources/rules/Issue176Spring4ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue176Spring4ControllerStub.java.txt
@@ -49,7 +49,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * No description
- * (Generated with springmvc-raml-parser v.0.10.8)
+ * (Generated with springmvc-raml-parser v.${project.version})
  * 
  */
 @RestController

--- a/springmvc-raml-parser/src/test/resources/rules/Issue176Spring4ControllerStub.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/Issue176Spring4ControllerStub.java.txt
@@ -49,7 +49,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * No description
- * (Generated with springmvc-raml-parser v.${project.version})
+ * (Generated with springmvc-raml-parser v.0.10.8)
  * 
  */
 @RestController

--- a/springmvc-raml-parser/src/test/resources/rules/RamlSchemaWithInheritanceTest.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/RamlSchemaWithInheritanceTest.java.txt
@@ -1,0 +1,241 @@
+-----------------------------------com.gen.test.model.Person.java-----------------------------------
+
+package com.gen.test.model;
+
+import java.io.Serializable;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+public class Person implements Serializable
+{
+
+    private String firstName;
+    private String lastName;
+    private Double age;
+
+    /**
+     * Creates a new Person.
+     * 
+     */
+    public Person() {
+        super();
+    }
+
+    /**
+     * Creates a new Person.
+     * 
+     */
+    public Person(String firstName, String lastName, Double age) {
+        super();
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.age = age;
+    }
+
+    /**
+     * Returns the firstName.
+     * 
+     * @return
+     *     firstName
+     */
+    public String getFirstName() {
+        return firstName;
+    }
+
+    /**
+     * Set the firstName.
+     * 
+     * @param firstName
+     *     the new firstName
+     */
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * Returns the lastName.
+     * 
+     * @return
+     *     lastName
+     */
+    public String getLastName() {
+        return lastName;
+    }
+
+    /**
+     * Set the lastName.
+     * 
+     * @param lastName
+     *     the new lastName
+     */
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * Returns the age.
+     * 
+     * @return
+     *     age
+     */
+    public Double getAge() {
+        return age;
+    }
+
+    /**
+     * Set the age.
+     * 
+     * @param age
+     *     the new age
+     */
+    public void setAge(Double age) {
+        this.age = age;
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder().append(firstName).append(lastName).append(age).toHashCode();
+    }
+
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if (this.getClass()!= other.getClass()) {
+            return false;
+        }
+        Person otherObject = ((Person) other);
+        return new EqualsBuilder().append(firstName, otherObject.firstName).append(lastName, otherObject.lastName).append(age, otherObject.age).isEquals();
+    }
+
+    public String toString() {
+        return new ToStringBuilder(this).append("firstName", firstName).append("lastName", lastName).append("age", age).toString();
+    }
+
+}
+-----------------------------------com.gen.test.model.User.java-----------------------------------
+
+package com.gen.test.model;
+
+import java.io.Serializable;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+public class User
+    extends Person
+    implements Serializable
+{
+
+    private String username;
+
+    /**
+     * Creates a new User.
+     * 
+     */
+    public User() {
+        super();
+    }
+
+    /**
+     * Creates a new User.
+     * 
+     */
+    public User(String firstName, String lastName, Double age, String username) {
+        super(firstName, lastName, age);
+        this.username = username;
+    }
+
+    /**
+     * Returns the username.
+     * 
+     * @return
+     *     username
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Set the username.
+     * 
+     * @param username
+     *     the new username
+     */
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder().appendSuper(super.hashCode()).append(username).toHashCode();
+    }
+
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if (this.getClass()!= other.getClass()) {
+            return false;
+        }
+        User otherObject = ((User) other);
+        return new EqualsBuilder().appendSuper(super.equals(otherObject)).append(username, otherObject.username).isEquals();
+    }
+
+    public String toString() {
+        return new ToStringBuilder(this).appendSuper(super.toString()).append("username", username).toString();
+    }
+
+}
+-----------------------------------com.gen.test.PersonController.java-----------------------------------
+
+package com.gen.test;
+
+import java.util.List;
+import javax.validation.Valid;
+import com.gen.test.model.Person;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * No description
+ * (Generated with springmvc-raml-parser v.0.10.9)
+ * 
+ */
+@RestController
+@RequestMapping(value = "/api/persons", produces = "application/json")
+@Validated
+public class PersonController {
+
+
+    /**
+     * No description
+     * 
+     */
+    @RequestMapping(value = "", method = RequestMethod.GET)
+    public List<Person> getPersons() {
+        return null; //TODO Autogenerated Method Stub. Implement me please.
+    }
+
+    /**
+     * No description
+     * 
+     */
+    @RequestMapping(value = "", method = RequestMethod.POST)
+    public Person createPerson(
+        @Valid
+        @RequestBody
+        Person person) {
+        return null; //TODO Autogenerated Method Stub. Implement me please.
+    }
+
+}

--- a/springmvc-raml-parser/src/test/resources/rules/RamlWithUnionTypeSpring4ControllerInterface.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/RamlWithUnionTypeSpring4ControllerInterface.java.txt
@@ -31,25 +31,6 @@ public class Device implements Serializable
         this.Notebook = Notebook;
     }
 
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
-    }
-
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-        if ((other instanceof Device) == false) {
-            return false;
-        }
-        Device otherObject = ((Device) other);
-        return new EqualsBuilder().isEquals();
-    }
-
-    public int hashCode() {
-        return new HashCodeBuilder().toHashCode();
-    }
-
     /**
      * Returns the Phone.
      * 
@@ -90,6 +71,28 @@ public class Device implements Serializable
         this.Notebook = Notebook;
     }
 
+    public int hashCode() {
+        return new HashCodeBuilder().append(Phone).append(Notebook).toHashCode();
+    }
+
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Device) == false) {
+            return false;
+        }
+        Device otherObject = ((Device) other);
+        return new EqualsBuilder().append(Phone, otherObject.Phone).append(Notebook, otherObject.Notebook).isEquals();
+    }
+
+    public String toString() {
+        return new ToStringBuilder().append("Phone", Phone).append("Notebook", Notebook).toString();
+    }
+
 }
 -----------------------------------com.gen.test.model.Notebook.java-----------------------------------
 
@@ -122,25 +125,6 @@ public class Notebook implements Serializable
         super();
         this.manufacturer = manufacturer;
         this.numberOfUSBPorts = numberOfUSBPorts;
-    }
-
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
-    }
-
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-        if ((other instanceof Notebook) == false) {
-            return false;
-        }
-        Notebook otherObject = ((Notebook) other);
-        return new EqualsBuilder().isEquals();
-    }
-
-    public int hashCode() {
-        return new HashCodeBuilder().toHashCode();
     }
 
     /**
@@ -183,6 +167,28 @@ public class Notebook implements Serializable
         this.numberOfUSBPorts = numberOfUSBPorts;
     }
 
+    public int hashCode() {
+        return new HashCodeBuilder().append(manufacturer).append(numberOfUSBPorts).toHashCode();
+    }
+
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Notebook) == false) {
+            return false;
+        }
+        Notebook otherObject = ((Notebook) other);
+        return new EqualsBuilder().append(manufacturer, otherObject.manufacturer).append(numberOfUSBPorts, otherObject.numberOfUSBPorts).isEquals();
+    }
+
+    public String toString() {
+        return new ToStringBuilder().append("manufacturer", manufacturer).append("numberOfUSBPorts", numberOfUSBPorts).toString();
+    }
+
 }
 -----------------------------------com.gen.test.model.Phone.java-----------------------------------
 
@@ -215,25 +221,6 @@ public class Phone implements Serializable
         super();
         this.manufacturer = manufacturer;
         this.numberOfSIMCards = numberOfSIMCards;
-    }
-
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
-    }
-
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-        if ((other instanceof Phone) == false) {
-            return false;
-        }
-        Phone otherObject = ((Phone) other);
-        return new EqualsBuilder().isEquals();
-    }
-
-    public int hashCode() {
-        return new HashCodeBuilder().toHashCode();
     }
 
     /**
@@ -274,6 +261,28 @@ public class Phone implements Serializable
      */
     public void setNumberOfSIMCards(Double numberOfSIMCards) {
         this.numberOfSIMCards = numberOfSIMCards;
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder().append(manufacturer).append(numberOfSIMCards).toHashCode();
+    }
+
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof Phone) == false) {
+            return false;
+        }
+        Phone otherObject = ((Phone) other);
+        return new EqualsBuilder().append(manufacturer, otherObject.manufacturer).append(numberOfSIMCards, otherObject.numberOfSIMCards).isEquals();
+    }
+
+    public String toString() {
+        return new ToStringBuilder().append("manufacturer", manufacturer).append("numberOfSIMCards", numberOfSIMCards).toString();
     }
 
 }

--- a/springmvc-raml-parser/src/test/resources/rules/RamlWithUnionTypeSpring4ControllerInterface.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/RamlWithUnionTypeSpring4ControllerInterface.java.txt
@@ -43,11 +43,11 @@ public class Device implements Serializable
             return false;
         }
         Device otherObject = ((Device) other);
-        return new EqualsBuilder().isEquals();
+        return EqualsBuilder.reflectionEquals(this, otherObject, false);
     }
 
     public int hashCode() {
-        return new HashCodeBuilder().toHashCode();
+        return HashCodeBuilder.reflectionHashCode(this, false);
     }
 
     /**
@@ -136,11 +136,11 @@ public class Notebook implements Serializable
             return false;
         }
         Notebook otherObject = ((Notebook) other);
-        return new EqualsBuilder().isEquals();
+        return EqualsBuilder.reflectionEquals(this, otherObject, false);
     }
 
     public int hashCode() {
-        return new HashCodeBuilder().toHashCode();
+        return HashCodeBuilder.reflectionHashCode(this, false);
     }
 
     /**
@@ -229,11 +229,11 @@ public class Phone implements Serializable
             return false;
         }
         Phone otherObject = ((Phone) other);
-        return new EqualsBuilder().isEquals();
+        return EqualsBuilder.reflectionEquals(this, otherObject, false);
     }
 
     public int hashCode() {
-        return new HashCodeBuilder().toHashCode();
+        return HashCodeBuilder.reflectionHashCode(this, false);
     }
 
     /**

--- a/springmvc-raml-parser/src/test/resources/rules/RamlWithUnionTypeSpring4ControllerInterface.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/RamlWithUnionTypeSpring4ControllerInterface.java.txt
@@ -82,7 +82,7 @@ public class Device implements Serializable
         if (other == this) {
             return true;
         }
-        if ((other instanceof Device) == false) {
+        if (this.getClass()!= other.getClass()) {
             return false;
         }
         Device otherObject = ((Device) other);
@@ -90,7 +90,7 @@ public class Device implements Serializable
     }
 
     public String toString() {
-        return new ToStringBuilder().append("Phone", Phone).append("Notebook", Notebook).toString();
+        return new ToStringBuilder(this).append("Phone", Phone).append("Notebook", Notebook).toString();
     }
 
 }
@@ -178,7 +178,7 @@ public class Notebook implements Serializable
         if (other == this) {
             return true;
         }
-        if ((other instanceof Notebook) == false) {
+        if (this.getClass()!= other.getClass()) {
             return false;
         }
         Notebook otherObject = ((Notebook) other);
@@ -186,7 +186,7 @@ public class Notebook implements Serializable
     }
 
     public String toString() {
-        return new ToStringBuilder().append("manufacturer", manufacturer).append("numberOfUSBPorts", numberOfUSBPorts).toString();
+        return new ToStringBuilder(this).append("manufacturer", manufacturer).append("numberOfUSBPorts", numberOfUSBPorts).toString();
     }
 
 }
@@ -274,7 +274,7 @@ public class Phone implements Serializable
         if (other == this) {
             return true;
         }
-        if ((other instanceof Phone) == false) {
+        if (this.getClass()!= other.getClass()) {
             return false;
         }
         Phone otherObject = ((Phone) other);
@@ -282,7 +282,7 @@ public class Phone implements Serializable
     }
 
     public String toString() {
-        return new ToStringBuilder().append("manufacturer", manufacturer).append("numberOfSIMCards", numberOfSIMCards).toString();
+        return new ToStringBuilder(this).append("manufacturer", manufacturer).append("numberOfSIMCards", numberOfSIMCards).toString();
     }
 
 }

--- a/springmvc-raml-parser/src/test/resources/rules/RamlWithUnionTypeSpring4ControllerInterface.java.txt
+++ b/springmvc-raml-parser/src/test/resources/rules/RamlWithUnionTypeSpring4ControllerInterface.java.txt
@@ -43,11 +43,11 @@ public class Device implements Serializable
             return false;
         }
         Device otherObject = ((Device) other);
-        return EqualsBuilder.reflectionEquals(this, otherObject, false);
+        return new EqualsBuilder().isEquals();
     }
 
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this, false);
+        return new HashCodeBuilder().toHashCode();
     }
 
     /**
@@ -136,11 +136,11 @@ public class Notebook implements Serializable
             return false;
         }
         Notebook otherObject = ((Notebook) other);
-        return EqualsBuilder.reflectionEquals(this, otherObject, false);
+        return new EqualsBuilder().isEquals();
     }
 
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this, false);
+        return new HashCodeBuilder().toHashCode();
     }
 
     /**
@@ -229,11 +229,11 @@ public class Phone implements Serializable
             return false;
         }
         Phone otherObject = ((Phone) other);
-        return EqualsBuilder.reflectionEquals(this, otherObject, false);
+        return new EqualsBuilder().isEquals();
     }
 
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this, false);
+        return new HashCodeBuilder().toHashCode();
     }
 
     /**

--- a/springmvc-raml-parser/src/test/resources/rules/SchemaWithInheritance.raml
+++ b/springmvc-raml-parser/src/test/resources/rules/SchemaWithInheritance.raml
@@ -1,0 +1,40 @@
+#%RAML 1.0
+title: Persons
+mediaType: application/json
+baseUri: /api
+types: 
+  Person: 
+    type: object
+    properties:
+      firstName: string
+      lastName: string
+      age: number
+  User:
+    type: Person
+    properties:
+      username: string
+
+/persons:
+  get:
+    responses:
+      200:
+        body: Person[]
+  post:
+    body: Person
+    responses:
+      201:
+        body:
+          application/json:
+            type: Person
+/users:
+  get:
+    responses:
+      200:
+        body: User[]
+  post:
+    body: User
+    responses:
+      201:
+        body:
+          application/json:
+            type: User


### PR DESCRIPTION
[GH-178] Updated generation for equals() method to use Apache Common _reflectionEquals()_ in order to avoid generating _equals()_ methods that will always return true when check by reference and check by _instanceof_ are successfull.

Generation of _hashCode()_ method updated to follow the same pattern as _equals()_ method generation.

Fixed the test that was failing due to hard coded value for plugin version in the Javadoc of generated controller.