### PR TITLE
Configurable serialization for generate POJO

### DIFF
--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/pojo/PojoBuilder.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/pojo/PojoBuilder.java
@@ -126,7 +126,9 @@ public class PojoBuilder extends AbstractBuilder {
 			withDefaultConstructor(className);
 
 			// Handle Serialization
-			implementsSerializable();
+			if(config.isMakeSerializale()) {
+				implementsSerializable();
+			}
 
 			// Add to shortcuts
 			this.codeModels.put(fullyQualifiedClassName, this.pojo);

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/pojo/PojoGenerationConfig.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/pojo/PojoGenerationConfig.java
@@ -43,9 +43,9 @@ public class PojoGenerationConfig {
 	
 	//If set to true, longs will be generated as BigIntegers
 	private boolean useBigIntegers = false;
-		
-		
-	
+
+	//If set to true, POJOs will be made serializable
+	private boolean makeSerializale = true;
 
 	public String getPojoPackage() {
 		return pojoPackage;
@@ -56,6 +56,10 @@ public class PojoGenerationConfig {
 
 	public boolean isUseLongIntegers() {
 		return useLongIntegers;
+	}
+
+	public boolean isMakeSerializale(){
+		return makeSerializale;
 	}
 
 	public boolean isGenerateHashcodeEqualsToString() {
@@ -103,6 +107,11 @@ public class PojoGenerationConfig {
 		return this;
 	}
 	
+	public PojoGenerationConfig withMakeSerializable(boolean makePOJOSerializable) {
+		this.makeSerializale = makePOJOSerializable;
+		return this;
+	}
+
 	public PojoGenerationConfig withJSR303Annotations(boolean generateJSR303Annotations) {
 		this.generateJSR303Annotations = generateJSR303Annotations;
 		return this;
@@ -130,7 +139,8 @@ public class PojoGenerationConfig {
 		.withBigDecimals(generationConfig.isUseBigDecimals())
 		.withBigIntegers(generationConfig.isUseBigIntegers())
 		.withJSR303Annotations(generationConfig.isIncludeJsr303Annotations())
-		.withHashcodeEqualsToString((generationConfig.isIncludeHashcodeAndEquals() && generationConfig.isIncludeToString()));
+		.withHashcodeEqualsToString((generationConfig.isIncludeHashcodeAndEquals() && generationConfig.isIncludeToString()))
+		.withMakeSerializable(generationConfig.isSerializable());
 	}
 	
 

--- a/springmvc-raml-plugin/README.md
+++ b/springmvc-raml-plugin/README.md
@@ -357,7 +357,7 @@ Creates a standalone `org.springframework.cloud.netflix.feign.FeignClient` (REST
 ## Contributing
 [Pull requests][] are welcome; Be a good citizen and create unit tests for any bugs squished or features added
 
-[GenerationConfig]: https://github.com/phoenixnap/springmvc-raml-plugin/blob/master/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/PojoGenerationConfig.java
+[GenerationConfig]: https://github.com/phoenixnap/springmvc-raml-plugin/blob/master/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/pojo/PojoGenerationConfig.java
 [Pull requests]: http://help.github.com/send-pull-requests
 [Apache License]: http://www.apache.org/licenses/LICENSE-2.0
 [Git]: http://help.github.com/set-up-git-redirect

--- a/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/JsonShema2PojoGenerationConfig.java
+++ b/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/JsonShema2PojoGenerationConfig.java
@@ -89,6 +89,12 @@ public class JsonShema2PojoGenerationConfig extends DefaultGenerationConfig
    protected Boolean includeHashcodeAndEquals = Boolean.TRUE;
 
    /**
+    * We will pass on this configuration to the jsonschema2pojo library for making the POJO <code>Serializable</code>
+    */
+   @Parameter(required = false, readonly = true, defaultValue = "true")
+   protected Boolean makeSerializable = Boolean.TRUE;
+
+   /**
     * We will pass on this configuration to the jsonschema2pojo library for generation of <code>toString</code> method
     */
    @Parameter(required = false, readonly = true, defaultValue = "true")
@@ -233,6 +239,15 @@ public class JsonShema2PojoGenerationConfig extends DefaultGenerationConfig
          return includeHashcodeAndEquals;
       }
       return super.isIncludeHashcodeAndEquals();
+   }
+
+   @Override
+   public boolean isSerializable()
+   {
+      if (makeSerializable != null) {
+         return makeSerializable;
+      }
+      return super.isSerializable();
    }
 
    @Override

--- a/springmvc-raml-plugin/src/test/java/com/phoenixnap/oss/ramlapisync/plugin/PojoGenerationConfigTest.java
+++ b/springmvc-raml-plugin/src/test/java/com/phoenixnap/oss/ramlapisync/plugin/PojoGenerationConfigTest.java
@@ -64,6 +64,7 @@ public class PojoGenerationConfigTest
       Assert.assertFalse(typeGenerationConfig.isGenerateJSR303Annotations());
       Assert.assertFalse(typeGenerationConfig.isUseCommonsLang3());
       Assert.assertFalse(typeGenerationConfig.isUseLongIntegers());
+      Assert.assertTrue(typeGenerationConfig.isMakeSerializale());
       mojo.execute();
    }
    
@@ -77,12 +78,14 @@ public class PojoGenerationConfigTest
       generationConfig.includeJsr303Annotations = true;
       generationConfig.useLongIntegers = true;
       generationConfig.useCommonsLang3 = true;
+      generationConfig.makeSerializable = false;
       //re-sync configs
       final PojoGenerationConfig typeGenerationConfig = mojo.mapGenerationConfigMapping();;
       Assert.assertFalse(typeGenerationConfig.isGenerateHashcodeEqualsToString());
       Assert.assertTrue(typeGenerationConfig.isGenerateJSR303Annotations());
       Assert.assertTrue(typeGenerationConfig.isUseCommonsLang3());
       Assert.assertTrue(typeGenerationConfig.isUseLongIntegers());
+      Assert.assertFalse(typeGenerationConfig.isMakeSerializale());
       mojo.execute();
    }
 


### PR DESCRIPTION
Add configuration to make POJO not implement serializable.
The default value for the configuration is kept to true so that existing behaviour to make POJO serializable continues to behave as expected.