### PR TITLE
Enforce Spring's alias semantics

### DIFF
--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/data/ApiParameterMetadata.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/data/ApiParameterMetadata.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang.NullArgumentException;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -166,22 +167,21 @@ public class ApiParameterMetadata {
 			throw new NullArgumentException("param");
 		}
 
-		RequestParam requestParam = param.getAnnotation(RequestParam.class);
+		RequestParam requestParam = AnnotationUtils.getAnnotation(param, RequestParam.class);
 		if (requestParam != null) {
 			annotatedName = requestParam.value();
 			nullable = !requestParam.required();
 		}
 
-		PathVariable pathVariable = param.getAnnotation(PathVariable.class);
+		PathVariable pathVariable = AnnotationUtils.getAnnotation(param, PathVariable.class);
 		if (pathVariable != null) {
 			resourceId = true;
 			annotatedName = pathVariable.value();
 		}
 
-		RequestBody requestBody = param.getAnnotation(RequestBody.class);
+		RequestBody requestBody = AnnotationUtils.getAnnotation(param, RequestBody.class);
 		if (requestBody != null) {
 			nullable = !requestBody.required();
-
 		}
 
 		this.name = resolveParameterName(annotatedName, param);
@@ -191,7 +191,7 @@ public class ApiParameterMetadata {
 			this.genericType = JavaTypeHelper.inferGenericType(param.getParameterizedType());
 		}
 
-		Example parameterExample = param.getAnnotation(Example.class);
+		Example parameterExample = AnnotationUtils.getAnnotation(param, Example.class);
 		if (parameterExample != null && StringUtils.hasText(parameterExample.value())) {
 			this.example = parameterExample.value();
 		}

--- a/springmvc-raml-parser/src/test/java/com/phoenixnap/oss/ramlapisync/data/ApiParameterMetadataTest.java
+++ b/springmvc-raml-parser/src/test/java/com/phoenixnap/oss/ramlapisync/data/ApiParameterMetadataTest.java
@@ -1,0 +1,66 @@
+package com.phoenixnap.oss.ramlapisync.data;
+
+import org.junit.Test;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class ApiParameterMetadataTest {
+    private static final String PATH_VARIABLE_WITH_VALUE_SPECIFIED = "pathVariableWithValueSpecified";
+    private static final String PATH_VARIABLE_WITH_NAME_SPECIFIED = "pathVariableWithNameSpecified";
+    private static final String REQUEST_PARAM_WITH_VALUE_SPECIFIED = "requestParamWithValueSpecified";
+    private static final String REQUEST_PARAM_WITH_NAME_SPECIFIED = "requestParamWithNameSpecified";
+
+    @Test
+    public void pathVariableValueShouldBeResolvedAsName() throws Exception {
+        // given
+
+        // when
+        ApiParameterMetadata apiParameterMetadata = new ApiParameterMetadata(Resource.class.getMethods()[0].getParameters()[0]);
+
+        // then
+        assertThat(apiParameterMetadata.getName(), equalTo(PATH_VARIABLE_WITH_VALUE_SPECIFIED));
+    }
+
+    @Test
+    public void pathVariableNameShouldBeResolvedAsName() throws Exception {
+        // given
+
+        // when
+        ApiParameterMetadata apiParameterMetadata = new ApiParameterMetadata(Resource.class.getMethods()[0].getParameters()[1]);
+
+        // then
+        assertThat(apiParameterMetadata.getName(), equalTo(PATH_VARIABLE_WITH_NAME_SPECIFIED));
+    }
+
+    @Test
+    public void requestParamValueShouldBeResolvedAsName() throws Exception {
+        // given
+
+        // when
+        ApiParameterMetadata apiParameterMetadata = new ApiParameterMetadata(Resource.class.getMethods()[0].getParameters()[2]);
+
+        // then
+        assertThat(apiParameterMetadata.getName(), equalTo(REQUEST_PARAM_WITH_VALUE_SPECIFIED));
+    }
+
+    @Test
+    public void requestParamNameShouldBeResolvedAsName() throws Exception {
+        // given
+
+        // when
+        ApiParameterMetadata apiParameterMetadata = new ApiParameterMetadata(Resource.class.getMethods()[0].getParameters()[3]);
+
+        // then
+        assertThat(apiParameterMetadata.getName(), equalTo(REQUEST_PARAM_WITH_NAME_SPECIFIED));
+    }
+
+    private interface Resource {
+        void resourceMethod(@PathVariable(PATH_VARIABLE_WITH_VALUE_SPECIFIED) String pathVariableWithValueSpecified,
+                            @PathVariable(name = PATH_VARIABLE_WITH_NAME_SPECIFIED) String pathVariableWithNameSpecified,
+                            @RequestParam(REQUEST_PARAM_WITH_VALUE_SPECIFIED) String requestParamWithValueSpecified,
+                            @RequestParam(name = REQUEST_PARAM_WITH_NAME_SPECIFIED) String requestParamWithNameSpecified);
+    }
+}


### PR DESCRIPTION
Spring's [@AliasFor](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/core/annotation/AliasFor.html) annotation was not taken into account during parsing SpringMVC resource. 

As a result the `RequestParam` and `PathVariable` name was recognized **only** if the annotations' `value` attribute was set. Annotations like `@PathVariable(name = "varName")` or `@RequestParam(name = "paramName")` were not parsed properly.