### PR TITLE
Add support for union types with inheritance

### DIFF
--- a/src/main/java/com/phoenixnap/oss/ramlplugin/raml2code/interpreters/UnionTypeInterpreter.java
+++ b/src/main/java/com/phoenixnap/oss/ramlplugin/raml2code/interpreters/UnionTypeInterpreter.java
@@ -126,7 +126,7 @@ public class UnionTypeInterpreter extends BaseTypeInterpreter {
 
 		for (TypeDeclaration objectProperty : objectType.of()) {
 			RamlInterpretationResult childResult = RamlInterpreterFactory.getInterpreterForType(objectProperty).interpret(document,
-					objectProperty, builderModel, true);
+					objectProperty, builderModel, false);
 
 			String childType = childResult.getResolvedClassOrBuiltOrObject().fullName();
 			builder.withField(objectProperty.name(), childType, RamlTypeHelper.getDescription(objectProperty), childResult.getValidations(),

--- a/src/test/java/com/phoenixnap/oss/ramlplugin/raml2code/interpreters/UnionTypeInterpretorTest.java
+++ b/src/test/java/com/phoenixnap/oss/ramlplugin/raml2code/interpreters/UnionTypeInterpretorTest.java
@@ -23,4 +23,12 @@ public class UnionTypeInterpretorTest extends AbstractRuleTestBase {
 		rule.apply(getControllerMetadata(), jCodeModel);
 		verifyGeneratedCode("RamlWithUnionTypeSpring4ControllerInterface");
 	}
+
+	@Test
+	public void shouldCreateValidCodeWhenUsingUnionTypesAndInheritance() throws Exception {
+		loadRaml("raml-with-union-types-and-inheritance.raml");
+		rule = new Spring4ControllerInterfaceRule();
+		rule.apply(getControllerMetadata(), jCodeModel);
+		verifyGeneratedCode("RamlWithUnionTypeAndInheritanceSpring4ControllerInterface");
+	}
 }

--- a/src/test/resources/ramls/raml-with-union-types-and-inheritance.raml
+++ b/src/test/resources/ramls/raml-with-union-types-and-inheritance.raml
@@ -1,0 +1,32 @@
+#%RAML 1.0
+title: API wih Union Types and Inheritance
+mediaType: application/json
+baseUri: /api
+
+types:
+  Manufactured:
+    type: object
+    properties:
+      manufacturer:
+        type: string
+  Phone:
+    type: Manufactured
+    properties:
+      numberOfSIMCards:
+        type: number
+  Notebook:
+    type: Manufactured
+    properties:
+      numberOfUSBPorts:
+        type: number
+  Device:
+    type: Phone | Notebook
+
+/devices:
+  description: "Api for devices"
+  /{id}:
+    get:
+      responses:
+        200:
+          body:
+            type: Device

--- a/src/test/resources/validations/RamlWithUnionTypeAndInheritanceSpring4ControllerInterface.java.txt
+++ b/src/test/resources/validations/RamlWithUnionTypeAndInheritanceSpring4ControllerInterface.java.txt
@@ -1,0 +1,390 @@
+-----------------------------------com.gen.test.model.Device.java-----------------------------------
+
+package com.gen.test.model;
+
+import java.io.Serializable;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+public class Device implements Serializable
+{
+
+    protected com.gen.test.model.Phone Phone;
+    protected com.gen.test.model.Notebook Notebook;
+
+    /**
+     * Creates a new Device.
+     *
+     */
+    public Device() {
+        super();
+    }
+
+    /**
+     * Creates a new Device.
+     *
+     */
+    public Device(com.gen.test.model.Phone Phone, com.gen.test.model.Notebook Notebook) {
+        super();
+        this.Phone = Phone;
+        this.Notebook = Notebook;
+    }
+
+    /**
+     * Returns the Phone.
+     *
+     * @return
+     *     Phone
+     */
+    @NotNull
+    @Valid
+    public com.gen.test.model.Phone getPhone() {
+        return Phone;
+    }
+
+    /**
+     * Set the Phone.
+     *
+     * @param Phone
+     *     the new Phone
+     */
+    public void setPhone(com.gen.test.model.Phone Phone) {
+        this.Phone = Phone;
+    }
+
+    /**
+     * Returns the Notebook.
+     *
+     * @return
+     *     Notebook
+     */
+    @NotNull
+    @Valid
+    public com.gen.test.model.Notebook getNotebook() {
+        return Notebook;
+    }
+
+    /**
+     * Set the Notebook.
+     *
+     * @param Notebook
+     *     the new Notebook
+     */
+    public void setNotebook(com.gen.test.model.Notebook Notebook) {
+        this.Notebook = Notebook;
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder().append(Phone).append(Notebook).toHashCode();
+    }
+
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if (this.getClass()!= other.getClass()) {
+            return false;
+        }
+        Device otherObject = ((Device) other);
+        return new EqualsBuilder().append(Phone, otherObject.Phone).append(Notebook, otherObject.Notebook).isEquals();
+    }
+
+    public String toString() {
+        return new ToStringBuilder(this).append("Phone", Phone).append("Notebook", Notebook).toString();
+    }
+
+}
+-----------------------------------com.gen.test.model.Manufactured.java-----------------------------------
+
+package com.gen.test.model;
+
+import java.io.Serializable;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+public class Manufactured implements Serializable
+{
+
+    protected String manufacturer;
+
+    /**
+     * Creates a new Manufactured.
+     *
+     */
+    public Manufactured() {
+        super();
+    }
+
+    /**
+     * Creates a new Manufactured.
+     *
+     */
+    public Manufactured(String manufacturer) {
+        super();
+        this.manufacturer = manufacturer;
+    }
+
+    /**
+     * Returns the manufacturer.
+     *
+     * @return
+     *     manufacturer
+     */
+    @NotNull
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    /**
+     * Set the manufacturer.
+     *
+     * @param manufacturer
+     *     the new manufacturer
+     */
+    public void setManufacturer(String manufacturer) {
+        this.manufacturer = manufacturer;
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder().append(manufacturer).toHashCode();
+    }
+
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if (this.getClass()!= other.getClass()) {
+            return false;
+        }
+        Manufactured otherObject = ((Manufactured) other);
+        return new EqualsBuilder().append(manufacturer, otherObject.manufacturer).isEquals();
+    }
+
+    public String toString() {
+        return new ToStringBuilder(this).append("manufacturer", manufacturer).toString();
+    }
+
+}
+-----------------------------------com.gen.test.model.Notebook.java-----------------------------------
+
+package com.gen.test.model;
+
+import java.io.Serializable;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+public class Notebook
+    extends Manufactured
+    implements Serializable
+{
+
+    protected Double numberOfUSBPorts;
+
+    /**
+     * Creates a new Notebook.
+     *
+     */
+    public Notebook() {
+        super();
+    }
+
+    /**
+     * Creates a new Notebook.
+     *
+     */
+    public Notebook(String manufacturer, Double numberOfUSBPorts) {
+        super(manufacturer);
+        this.numberOfUSBPorts = numberOfUSBPorts;
+    }
+
+    /**
+     * Returns the manufacturer.
+     *
+     * @return
+     *     manufacturer
+     */
+    @NotNull
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    /**
+     * Returns the numberOfUSBPorts.
+     *
+     * @return
+     *     numberOfUSBPorts
+     */
+    @NotNull
+    public Double getNumberOfUSBPorts() {
+        return numberOfUSBPorts;
+    }
+
+    /**
+     * Set the numberOfUSBPorts.
+     *
+     * @param numberOfUSBPorts
+     *     the new numberOfUSBPorts
+     */
+    public void setNumberOfUSBPorts(Double numberOfUSBPorts) {
+        this.numberOfUSBPorts = numberOfUSBPorts;
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder().appendSuper(super.hashCode()).append(numberOfUSBPorts).toHashCode();
+    }
+
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if (this.getClass()!= other.getClass()) {
+            return false;
+        }
+        Notebook otherObject = ((Notebook) other);
+        return new EqualsBuilder().appendSuper(super.equals(otherObject)).append(numberOfUSBPorts, otherObject.numberOfUSBPorts).isEquals();
+    }
+
+    public String toString() {
+        return new ToStringBuilder(this).appendSuper(super.toString()).append("numberOfUSBPorts", numberOfUSBPorts).toString();
+    }
+
+}
+-----------------------------------com.gen.test.model.Phone.java-----------------------------------
+
+package com.gen.test.model;
+
+import java.io.Serializable;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+public class Phone
+    extends Manufactured
+    implements Serializable
+{
+
+    protected Double numberOfSIMCards;
+
+    /**
+     * Creates a new Phone.
+     *
+     */
+    public Phone() {
+        super();
+    }
+
+    /**
+     * Creates a new Phone.
+     *
+     */
+    public Phone(String manufacturer, Double numberOfSIMCards) {
+        super(manufacturer);
+        this.numberOfSIMCards = numberOfSIMCards;
+    }
+
+    /**
+     * Returns the manufacturer.
+     *
+     * @return
+     *     manufacturer
+     */
+    @NotNull
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    /**
+     * Returns the numberOfSIMCards.
+     *
+     * @return
+     *     numberOfSIMCards
+     */
+    @NotNull
+    public Double getNumberOfSIMCards() {
+        return numberOfSIMCards;
+    }
+
+    /**
+     * Set the numberOfSIMCards.
+     *
+     * @param numberOfSIMCards
+     *     the new numberOfSIMCards
+     */
+    public void setNumberOfSIMCards(Double numberOfSIMCards) {
+        this.numberOfSIMCards = numberOfSIMCards;
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder().appendSuper(super.hashCode()).append(numberOfSIMCards).toHashCode();
+    }
+
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if (this.getClass()!= other.getClass()) {
+            return false;
+        }
+        Phone otherObject = ((Phone) other);
+        return new EqualsBuilder().appendSuper(super.equals(otherObject)).append(numberOfSIMCards, otherObject.numberOfSIMCards).isEquals();
+    }
+
+    public String toString() {
+        return new ToStringBuilder(this).appendSuper(super.toString()).append("numberOfSIMCards", numberOfSIMCards).toString();
+    }
+
+}
+-----------------------------------com.gen.test.ApiDeviceController.java-----------------------------------
+
+package com.gen.test;
+
+import com.gen.test.model.Device;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * Api for devices
+ * (Generated with springmvc-raml-parser v.2.1.0)
+ *
+ */
+@RestController
+@Validated
+@RequestMapping(value = "/api/devices", produces = "application/json")
+public interface ApiDeviceController {
+
+
+    /**
+     * No description
+     *
+     */
+    @RequestMapping(value = "/{id}", method = RequestMethod.GET)
+    public ResponseEntity<Device> getDeviceById(
+        @PathVariable
+        String id);
+
+}


### PR DESCRIPTION
Currently union type interpreter generates code correctly only if union types don't extend other user-defined types.

For example let's look at the schema used for a unit test

```
types:
  Phone:
    type: object
    properties:
      manufacturer:
        type: string
      numberOfSIMCards:
        type: number
  Notebook:
    type: object
    properties:
      manufacturer:
        type: string
      numberOfUSBPorts:
        type: number
  Device:
    type: Phone | Notebook
```

If I change Phone and Notebook types to extend another custom type
```
types:
  Manufactured:
    type: object
    properties:
     manufacturer:
        type: string
  Phone:
    type: Manufactured
    properties:
      numberOfSIMCards:
        type: number
  Notebook:
    type: Manufactured
    properties:
      numberOfUSBPorts:
        type: number
  Device:
    type: Phone | Notebook
```
Interpreter ignores Phone/Notebook types and Device POJO looks like this:
```
public class Device implements Serializable {
    protected Manufactured Phone;
    protected Manufactured Notebook;
}
```

This PR contains a fix for this behavior, I believe expected result is similar to
```
public class Device implements Serializable {
  protected com.gen.test.model.Phone Phone;
  protected com.gen.test.model.Notebook Notebook;
}
```
Could you please review it and maybe propose a better solution?